### PR TITLE
Typo on line 82.

### DIFF
--- a/classification.md
+++ b/classification.md
@@ -80,7 +80,7 @@ Where the sum is taken over all pixels. Here is the procedure visualized:
 
 <div class="fig figcenter fighighlight">
   <img src="/assets/nneg.jpeg">
-  <div class="figcaption">An example of using pixel-wise differences to compare two images with L1 distance (for one color channel in this example). Two two images are subtracted elementwise and then all differences are added up to a single number. If two images are identical the result will be zero. But if the images are very different the result will be large.</div>
+  <div class="figcaption">An example of using pixel-wise differences to compare two images with L1 distance (for one color channel in this example). Two images are subtracted elementwise and then all differences are added up to a single number. If two images are identical the result will be zero. But if the images are very different the result will be large.</div>
 </div>
 
 Lets also look at how we might implement the classifier in code. First, lets load the CIFAR-10 data into memory as 4 arrays: the training data/labels and the test data/labels. In the code below, `Xtr` (of size 50,000 x 32 x 32 x 3) holds all the images in the training set, and a corresponding 1-dimensional array `Ytr` (of length 50,000) holds the training labels (from 0 to 9):


### PR DESCRIPTION
Changed "Two two" to just "two". Only one set of two images are subtracted in the example picture "/assets/nneg.jpeg".