### PR TITLE
Add missing 'self' in code snippet

### DIFF
--- a/neural-networks-1.md
+++ b/neural-networks-1.md
@@ -38,7 +38,7 @@ An example code for forward-propagating a single neuron might look as follows:
 ```python
 class Neuron:
   # ... 
-  def forward(inputs):
+  def forward(self, inputs):
     """ assume inputs and weights are 1-D numpy arrays and bias is a number """
     cell_body_sum = np.sum(inputs * self.weights) + self.bias
     firing_rate = 1.0 / (1.0 + math.exp(-cell_body_sum)) # sigmoid activation function


### PR DESCRIPTION
Fix typo: add the missing "self" argument in a python method, in a code snippet.
