### PR TITLE
fix typo

### DIFF
--- a/classification.md
+++ b/classification.md
@@ -225,7 +225,7 @@ In cases where the size of your training data (and therefore also the validation
 
 <div class="fig figcenter fighighlight">
   <img src="/assets/crossval.jpeg">
-  <div class="figcaption">Common data splits. A training and test set is given. The training set is split into folds (for example 5 folds here). The folds 1-4 become the training set. One fold (e.g. fold 5 here in yellow) is denoted as the Validation fold and is used to tune the hyperparameters. Cross-validation goes a step further iterates over the choice of which fold is the validation fold, separately from 1-5. This would be referred to as 5-fold cross-validation. In the very end once the model is trained and all the best hyperparameters were determined, the model is evaluated a single time on the test data (red).</div>
+  <div class="figcaption">Common data splits. A training and test set is given. The training set is split into folds (for example 5 folds here). The folds 1-4 become the training set. One fold (e.g. fold 5 here in yellow) is denoted as the Validation fold and is used to tune the hyperparameters. Cross-validation goes a step further and iterates over the choice of which fold is the validation fold, separately from 1-5. This would be referred to as 5-fold cross-validation. In the very end once the model is trained and all the best hyperparameters were determined, the model is evaluated a single time on the test data (red).</div>
 </div>
 
 <a name='procon'></a>


### PR DESCRIPTION
Add a missing `and` to change 
```
Cross-validation goes a step further iterates over
```
into 
```
Cross-validation goes a step further and iterates over
```