### PR TITLE
Update linear-classify.md to fix demo link

### DIFF
--- a/linear-classify.md
+++ b/linear-classify.md
@@ -338,14 +338,15 @@ where the probabilites are now more diffuse. Moreover, in the limit where the we
 
 ### Interactive web demo
 
-<a href="http://vision.stanford.edu/teaching/cs231n/linear-classify-demo" style="text-decoration:none;">
-<div class="fig figcenter fighighlight">
-  <img src="/assets/classifydemo.jpeg">
-  <div class="figcaption">We have written an interactive web demo to help your intuitions with linear classifiers. The demo visualizes the loss functions discussed in this section using a toy 3-way classification on 2D data. The demo also jumps ahead a bit and performs the optimization, which we will discuss in full detail in the next section.
-  </div>
+<div>
+  <a href="http://vision.stanford.edu/teaching/cs231n/linear-classify-demo" style="text-decoration:none;">
+    <div class="fig figcenter fighighlight">
+      <img src="/assets/classifydemo.jpeg">
+      <div class="figcaption">We have written an interactive web demo to help your intuitions with linear classifiers. The demo visualizes the loss functions discussed in this section using a toy 3-way classification on 2D data. The demo also jumps ahead a bit and performs the optimization, which we will discuss in full detail in the next section.
+      </div>
+    </div>
+  </a>
 </div>
-</a>
-
 
 <a name='summary'></a>
 


### PR DESCRIPTION
The anchor tag for demo link are processed in a way that start and closing tags end up being wrapped in paragraph tags individually.
Interestingly, issue seen on http://cs231n.github.io/linear-classify/#webdemo but not on https://github.com/cs231n/cs231n.github.io/blob/master/linear-classify.md#interactive-web-demo.
Wrapped with div to fix it.
