### PR TITLE
Workaround for kramdown HTML parsing error

### DIFF
--- a/linear-classify.md
+++ b/linear-classify.md
@@ -338,13 +338,13 @@ where the probabilites are now more diffuse. Moreover, in the limit where the we
 
 ### Interactive web demo
 
-<a href="http://vision.stanford.edu/teaching/cs231n/linear-classify-demo" style="text-decoration:none;">
 <div class="fig figcenter fighighlight">
+<a href="http://vision.stanford.edu/teaching/cs231n/linear-classify-demo" style="text-decoration:none;">
   <img src="/assets/classifydemo.jpeg">
   <div class="figcaption">We have written an interactive web demo to help your intuitions with linear classifiers. The demo visualizes the loss functions discussed in this section using a toy 3-way classification on 2D data. The demo also jumps ahead a bit and performs the optimization, which we will discuss in full detail in the next section.
   </div>
-</div>
 </a>
+</div>
 
 
 <a name='summary'></a>


### PR DESCRIPTION
@karpathy Kramdown is not very good in parsing HTML inside a markdown.

In original markdown:

``` html
<a href="http://vision.stanford.edu/teaching/cs231n/linear-classify-demo" style="text-decoration:none;">
<div class="fig figcenter fighighlight">
   <img src="/assets/classifydemo.jpeg">
   <div class="figcaption">We have written an interactive web demo to help your intuitions with linear classifiers. The demo visualizes the loss functions discussed in this section using a toy 3-way classification on 2D data. The demo also jumps ahead a bit and performs the optimization, which we will discuss in full detail in the next section.
   </div>
</div>
</a>
```

It is interpreted as:

``` html
<p><a href="http://vision.stanford.edu/teaching/cs231n/linear-classify-demo" style="text-decoration:none;"></a></p>
<div class="fig figcenter fighighlight">
  <img src="/assets/classifydemo.jpeg" />
  <div class="figcaption">We have written an interactive web demo to help your intuitions with linear classifiers. The demo visualizes the loss functions discussed in this section using a toy 3-way classification on 2D data. The demo also jumps ahead a bit and performs the optimization, which we will discuss in full detail in the next section.
  </div>
</div>
<p>&lt;/a&gt;</p> <!-- Link element is broken! -->
```

To overcome kramdown's weakness, make `<div>` the outermost element instead of `<a>`:

``` html
<div class="fig figcenter fighighlight">
<a href="http://vision.stanford.edu/teaching/cs231n/linear-classify-demo" style="text-decoration:none;">
  <img src="/assets/classifydemo.jpeg" />
  <div class="figcaption">We have written an interactive web demo to help your intuitions with linear classifiers. The demo visualizes the loss functions discussed in this section using a toy 3-way classification on 2D data. The demo also jumps ahead a bit and performs the optimization, which we will discuss in full detail in the next section.
  </div>
</a>
</div>
```

From http://kramdown.gettalong.org/syntax.html#html-blocks

> The following HTML tags count as span-level HTML tags and won’t start an HTML block if found at the beginning of an HTML block line:
> 
> **a** abbr acronym b big bdo br button cite code del dfn em i img input
> ins kbd label option q rb rbc rp rt rtc ruby samp select small span
> strong sub sup textarea tt var
