### PR TITLE
fixed a typo xrange() -> range()

### DIFF
--- a/classification.md
+++ b/classification.md
@@ -127,7 +127,7 @@ class NearestNeighbor(object):
     Ypred = np.zeros(num_test, dtype = self.ytr.dtype)
 
     # loop over all test rows
-    for i in xrange(num_test):
+    for i in range(num_test):
       # find the nearest training image to the i'th test image
       # using the L1 distance (sum of absolute value differences)
       distances = np.sum(np.abs(self.Xtr - X[i,:]), axis = 1)


### PR DESCRIPTION
xrange() is deprecated in Python 3.x. consider using range() instead.