### PR TITLE
neural-networks-case-study.md - loss mistake

### DIFF
--- a/neural-networks-case-study.md
+++ b/neural-networks-case-study.md
@@ -124,7 +124,7 @@ reg_loss = 0.5*reg*np.sum(W*W)
 loss = data_loss + reg_loss
 ```
 
-In this code, the regularization strength \\(\lambda\\) is stored inside the `reg`. The convenience factor of `0.5` multiplying the regularization will become clear in a second. Evaluating this in the beginning (with random parameters) might give us `loss = 1.1`, which is `np.log(1.0/3)`, since with small initial random weights all probabilities assigned to all classes are about one third. We now want to make the loss as low as possible, with `loss = 0` as the absolute lower bound. But the lower the loss is, the higher are the probabilities assigned to the correct classes for all examples.
+In this code, the regularization strength \\(\lambda\\) is stored inside the `reg`. The convenience factor of `0.5` multiplying the regularization will become clear in a second. Evaluating this in the beginning (with random parameters) might give us `loss = 1.1`, which is `-np.log(1.0/3)`, since with small initial random weights all probabilities assigned to all classes are about one third. We now want to make the loss as low as possible, with `loss = 0` as the absolute lower bound. But the lower the loss is, the higher are the probabilities assigned to the correct classes for all examples.
 
 <a name='grad'></a>
 


### PR DESCRIPTION
The cross entropy loss should be -log(1/3)=1.1 instead of log(1/3).