### PR TITLE
Added first draft of Backpropagation for Basic Matrix Operations course notes using denominator layout

### DIFF
--- a/student-contributions/BackPropagationBasicMatrixOperations.bib
+++ b/student-contributions/BackPropagationBasicMatrixOperations.bib
@@ -1,0 +1,9 @@
+@misc{wiki:Matrix_calculus,
+   author = "Wikipedia",
+   title = "{Matrix calculus} --- {W}ikipedia{,} The Free Encyclopedia",
+   year = "2021",
+   url = {http://en.wikipedia.org/w/index.php?title=Matrix\%20calculus&oldid=1027030038},
+   note = "[Online; accessed 13-June-2021]"
+}
+
+@misc{li_krishna_xu_2021, place={Stanford}, title={Convolutional Neural Networks}, url={http://cs231n.stanford.edu/slides/2021/lecture_5.pdf}, journal={CS231N Lectures}, publisher={CA}, author={Li, Fei-Fei and Krishna, Ranjay and Xu, Danfei}, year={2021}, month={4}}

--- a/student-contributions/BackPropagationBasicMatrixOperations.tex
+++ b/student-contributions/BackPropagationBasicMatrixOperations.tex
@@ -29,6 +29,9 @@
 \renewcommand{\headrulewidth}{0pt} % and the line
 }
 
+\usepackage{biblatex}
+\addbibresource{BackPropagationBasicMatrixOperations.bib}
+
 % hyperref package doesn't seem to be working.
 
 
@@ -76,7 +79,7 @@
 This document is primarily targeted towards CS231N students who don't have a formal background in vector and matrix calculus.
 
 \subsection{Learning Goals}
-CS231N assignments have a heavy emphasis on vector and matrix calculus. Several different notation and layout conventions are popular in the literature which can be confusing and overwhelming for students just starting out with vector and matrix calculus. This document firmly aligns and sticks with the layout conventions for matrix calculus taught in CS231N lectures. This document hopes to bring the students who lack a formal background in vector and matrix calculus up to speed as well as serve as a reference while solving the various assignments. 
+CS231N assignments have a heavy emphasis on vector and matrix calculus. Several different notation and layout conventions are popular in the literature which can be confusing and overwhelming for students just starting out with vector and matrix calculus. This document firmly aligns and sticks with the layout conventions for matrix calculus taught in CS231N lectures \cite{li_krishna_xu_2021}. This document hopes to bring the students who lack a formal background in vector and matrix calculus up to speed as well as serve as a reference while solving the various assignments. 
 
 \subsection{Content}
 Through small non-trivial examples, we show how and why certain backpropagation operations reduce to the equations they reduce to for basic operations such as matrix multiplication, some element-wise operation on a matrix, element-wise operations between two matrices, reductions of a matrix to a vector and broadcasting of a vector to a matrix. The example matrices and vectors are deliberately kept small to ensure one can convince oneself or alternately verify on paper if the contents of this document are correct (please feel free to submit bugs or corrections). The examples considered while small are kept as general as possible throughout the derivations. Therefore, a motivated student can easily extend these examples to general proofs.
@@ -94,7 +97,7 @@ Each section from section \ref{Matrix Multiplication} onward is written independ
 \printnomenclature
 
 \section{Layout Convention}
-Given a vector $\vecr{y}$ where $\bm{y} \in \mathbb{R}^{m}$ and a vector $\bm{x}$ where $\bm{x} \in \mathbb{R}^{n}$, we are going to follow the \textbf{denominator layout} convention whereby $\frac{\partial y}{\partial x}$ is written as $n \times m$ matrix. This is in contrast to the \textbf{numerator layout} whereby $\frac{\partial y}{\partial x}$ is written as $m \times n$ matrix. 
+Given a vector $\vecr{y}$ where $\bm{y} \in \mathbb{R}^{m}$ and a vector $\bm{x}$ where $\bm{x} \in \mathbb{R}^{n}$, we are going to follow the \textbf{denominator layout} convention whereby $\frac{\partial y}{\partial x}$ is written as $n \times m$ matrix. This is in contrast to the \textbf{numerator layout} whereby $\frac{\partial y}{\partial x}$ is written as $m \times n$ matrix. For more details, please refer to the Wikipedia page \cite{wiki:Matrix_calculus}.
 
 For example, if $\bm{x} \in \mathbb{R}^{3}$ and $\bm{y} \in \mathbb{R}^{2}$ then:
 
@@ -203,6 +206,7 @@ Let $\matr{X}$ be a $2 \times 3$ matrix, and let $\matr{Y}$ be a $3 \times 2$ ma
 x_{1,1} & x_{1,2} & x_{1,3} \\%[0.5em]
 x_{2,1} & x_{2,2} & x_{2,3} \\%[0.5em]
 \end{bmatrix} &
+\nonumber
 \end{flalign}
 
 \begin{flalign}
@@ -212,6 +216,7 @@ y_{1,1} & y_{1,2} \\%[0.5em]
 y_{2,1} & y_{2,2} \\%[0.5em]
 y_{3,1} & y_{3,2} \\%[0.5em]
 \end{bmatrix} &
+\nonumber
 \end{flalign}
 
 \vspace{1em}
@@ -223,12 +228,14 @@ z_{1,1} & z_{1,2}\\[0.5em]
 z_{2,1} & z_{2,2}\\[0.5em]
 \end{bmatrix}
 &
+\nonumber
 \\
 &=
 \begin{bmatrix}
 x_{1,1}.y_{1,1} + x_{1,2}.y_{2,1} + x_{1,3}.y_{3,1} & x_{1,1}.y_{1,2} + x_{1,2}.y_{2,2} + x_{1,3}.y_{3,2}\\[0.5em]
 x_{2,1}.y_{1,1} + x_{2,2}.y_{2,1} + x_{2,3}.y_{3,1} & x_{2,1}.y_{1,2} + x_{2,2}.y_{2,2} + x_{2,3}.y_{3,2}\\[0.5em]
 \end{bmatrix}
+\nonumber
 \end{flalign}
 
 \subsection{Backward Pass}
@@ -239,16 +246,16 @@ We are given $\frac{\partial L}{\partial \matr{Z}}$. It will be of shape $2 \tim
 \begin{bmatrix}
 \frac{\partial L}{\partial z_{1,1}} & \frac{\partial L}{\partial z_{1,2}} \\[0.5em]
 \frac{\partial L}{\partial z_{2,1}} & \frac{\partial L}{\partial z_{2,2}} \\[0.5em]
-\end{bmatrix} & \eqncomment{$\frac{\partial L}{\partial \matr{Z}}$ is the same shape as $\matr{Z}$ as $L$ is a scalar}
+\end{bmatrix} & \eqncomment{$\frac{\partial L}{\partial \matr{Z}}$ is the same shape as $\matr{Z}$ as $L$ is a scalar} \label{dZ_matrix_multiplication}
 \end{flalign}
 
 \noindent We need to compute $\frac{\partial L}{\partial \matr{X}}$ and $\frac{\partial L}{\partial \matr{Y}}$. Using chain rule, we get:
 
-\begin{flalign} \label{dX}
+\begin{flalign} \label{dX_matrix_multiplication}
 \frac{\partial L}{\partial \matr{X}} &= \frac{\partial \matr{Z}}{\partial \matr{X}}\frac{\partial L}{\partial \matr{Z}} &
 \end{flalign}
 
-\begin{flalign} \label{dY}
+\begin{flalign} \label{dY_matrix_multiplication}
 \frac{\partial L}{\partial \matr{Y}} &= \frac{\partial \matr{Z}}{\partial \matr{Y}}\frac{\partial L}{\partial \matr{Z}} &
 \end{flalign}
 
@@ -267,7 +274,7 @@ To compute $\frac{\partial L}{\partial \matr{X}}$, we need to compute $\frac{\pa
 \end{bmatrix}
 & \eqncomment{$\matr{X}$, $\matr{Z}$ are being treated as column vectors. Therefore, $\frac{\partial \matr{Z}}{\partial \matr{X}}$ is of shape $6\times4$.}
 \nonumber \\
-\label{dZbydX}
+\label{dZbydX_matrix_multiplication}
 &=
 \begin{bmatrix}
 y_{1,1} & y_{1,2} & 0 & 0 \\[0.5em]
@@ -279,10 +286,10 @@ y_{3,1} & y_{3,2} & 0 & 0 \\[0.5em]
 \end{bmatrix}
 \end{flalign}
 
-\noindent Now, $\frac{\partial L}{\partial \matr{Z}}$ expressed as a column vector will be:
+\noindent Now, $\frac{\partial L}{\partial \matr{Z}}$ in equation \ref{dZ_matrix_multiplication} expressed as a column vector will be:
 
 \begin{flalign}
-\label{dZAsColumnVector}
+\label{dZAsColumnVector_matrix_multiplication}
 \frac{\partial L}{\partial \matr{Z}} &=
 \begin{bmatrix}
 \frac{\partial L}{\partial z_{1,1}} \\[0.7em]
@@ -292,7 +299,7 @@ y_{3,1} & y_{3,2} & 0 & 0 \\[0.5em]
 \end{bmatrix} & \eqncomment{Reshaping $\frac{\partial L}{\partial \matr{Z}}$ from shape $2 \times 2$ to $4 \times 1$}
 \end{flalign}
 
-\noindent Plugging equations \ref{dZbydX} and \ref{dZAsColumnVector} into equation \ref{dX}, we get:
+\noindent Plugging equations \ref{dZbydX_matrix_multiplication} and \ref{dZAsColumnVector_matrix_multiplication} into equation \ref{dX_matrix_multiplication}, we get:
 
 \begin{flalign}
 \frac{\partial L}{\partial \matr{X}} &=
@@ -323,10 +330,10 @@ y_{3,1}.\frac{\partial L}{\partial z_{1,1}} + y_{3,2}.\frac{\partial L}{\partial
 y_{1,1}.\frac{\partial L}{\partial z_{2,1}} + y_{1,2}.\frac{\partial L}{\partial z_{2,2}} \\[0.7em]
 y_{2,1}.\frac{\partial L}{\partial z_{2,1}} + y_{2,2}.\frac{\partial L}{\partial z_{2,2}} \\[0.7em]
 y_{3,1}.\frac{\partial L}{\partial z_{2,1}} + y_{3,2}.\frac{\partial L}{\partial z_{2,2}} \\[0.7em]
-\end{bmatrix} \label{dXAsColumnVector}
+\end{bmatrix} \label{dXAsColumnVector_matrix_multiplication}
 \end{flalign}
 
-\noindent Reshaping column vector in equation \ref{dXAsColumnVector} as a matrix of shape $\matr{X}$, we get:
+\noindent Reshaping column vector in equation \ref{dXAsColumnVector_matrix_multiplication} as a matrix of shape $\matr{X}$, we get:
 \begin{flalign}
 \frac{\partial L}{\partial \matr{X}} &=
 \begin{bmatrix}
@@ -389,10 +396,10 @@ x_{1,2} & 0 & x_{2,2} & 0 \\[0.5em]
 0 & x_{1,2} & 0 & x_{2,2} \\[0.5em]
 x_{1,3} & 0 & x_{2,3} & 0 \\[0.5em]
 0 & x_{1,3} & 0 & x_{2,3} \\[0.5em]
-\end{bmatrix} \label{dZbydY}
+\end{bmatrix} \label{dZbydY_matrix_multiplication}
 \end{flalign}
 
-\noindent Plugging equations \ref{dZbydY} and \ref{dZAsColumnVector} into equation \ref{dY}, we get:
+\noindent Plugging equations \ref{dZbydY_matrix_multiplication} and \ref{dZAsColumnVector_matrix_multiplication} into equation \ref{dY_matrix_multiplication}, we get:
 
 \begin{flalign}
 \frac{\partial L}{\partial \matr{Y}} &=
@@ -420,10 +427,10 @@ x_{1,2}.\frac{\partial L}{\partial z_{1,1}} + x_{2,2}.\frac{\partial L}{\partial
 x_{1,2}.\frac{\partial L}{\partial z_{1,2}} + x_{2,2}.\frac{\partial L}{\partial z_{2,2}} \\[0.7em]
 x_{1,3}.\frac{\partial L}{\partial z_{1,1}} + x_{2,3}.\frac{\partial L}{\partial z_{2,1}} \\[0.7em]
 x_{1,3}.\frac{\partial L}{\partial z_{1,2}} + x_{2,3}.\frac{\partial L}{\partial z_{2,2}} \\[0.7em]
-\end{bmatrix} \label{dYAsColumnVector}
+\end{bmatrix} \label{dYAsColumnVector_matrix_multiplication}
 \end{flalign}
 
-\noindent Reshaping column vector in equation \ref{dYAsColumnVector} as a matrix of shape $\matr{Y}$, we get:
+\noindent Reshaping column vector in equation \ref{dYAsColumnVector_matrix_multiplication} as a matrix of shape $\matr{Y}$, we get:
 
 \begin{flalign}
 \frac{\partial L}{\partial \matr{Y}} &=
@@ -475,6 +482,7 @@ x_{1,1} & x_{1,2} \\%[0.5em]
 x_{2,1} & x_{2,2} \\%[0.5em]
 x_{3,1} & x_{3,2} \\%[0.5em]
 \end{bmatrix} &
+\nonumber
 \end{flalign}
 
 \noindent $\matr{Z}$ can be expressed as:
@@ -493,6 +501,7 @@ g(x_{1,1}) & g(x_{1,2}) \\[0.5em]
 g(x_{2,1}) & g(x_{2,2}) \\[0.5em]
 g(x_{3,1}) & g(x_{3,2}) \\[0.5em]
 \end{bmatrix}
+\nonumber
 \end{flalign}
 
 \subsection{Backward Pass}
@@ -505,6 +514,7 @@ We have $\frac{\partial L}{\partial \matr{Z}}$ of shape $3 \times 2$.
 \frac{\partial L}{\partial z_{2,1}} & \frac{\partial L}{\partial z_{2,2}} \\[0.5em]
 \frac{\partial L}{\partial z_{3,1}} & \frac{\partial L}{\partial z_{3,2}} \\[0.5em]
 \end{bmatrix} & \eqncomment{$\frac{\partial L}{\partial \matr{Z}}$ is the same shape as $\matr{Z}$ as $L$ is a scalar}
+\label{dZ_elewise_single_matrix}
 \end{flalign}
 
 \noindent We now need to compute $\frac{\partial L}{\partial \matr{X}}$. Using chain rule, we get:
@@ -540,7 +550,7 @@ g'(x_{1,1}) & 0 & 0 & 0 & 0 & 0 \\[0.0em]
 \end{bmatrix*}
 \end{flalign}
 
-\noindent Now, $\frac{\partial L}{\partial \matr{Z}}$ expressed as a column vector will be:
+\noindent Now, $\frac{\partial L}{\partial \matr{Z}}$ in equation \ref{dZ_elewise_single_matrix} expressed as a column vector will be:
 
 \begin{flalign} \label{dZAsColumnVector_elewise_single_matrix}
 \frac{\partial L}{\partial \matr{Z}} &=
@@ -554,7 +564,6 @@ g'(x_{1,1}) & 0 & 0 & 0 & 0 & 0 \\[0.0em]
 \end{bmatrix}
 & \eqncomment{Reshaping $\frac{\partial L}{\partial \matr{Z}}$ from shape $3 \times 2$ to $6 \times 1$}
 \end{flalign}
-
 
 \noindent Plugging equations \ref{dZbydX_elewise_single_matrix} and \ref{dZAsColumnVector_elewise_single_matrix} into equation \ref{dX_elewise_single_matrix}, we get:
 
@@ -647,6 +656,7 @@ x_{1,1} & x_{1,2} \\%[0.5em]
 x_{2,1} & x_{2,2} \\%[0.5em]
 x_{3,1} & x_{3,2} \\%[0.5em]
 \end{bmatrix} &
+\nonumber
 \end{flalign}
 
 \begin{flalign}
@@ -656,6 +666,7 @@ y_{1,1} & y_{1,2} \\%[0.5em]
 y_{2,1} & y_{2,2} \\%[0.5em]
 y_{3,1} & y_{3,2} \\%[0.5em]
 \end{bmatrix} &
+\nonumber
 \end{flalign}
 
 \noindent Given $\matr{Z} = \matr{X} \circ \matr{Y}$, $\matr{Z}$ is a $3 \times 2$ matrix which can be expressed as:
@@ -667,6 +678,7 @@ z_{2,1} & z_{2,2}\\[0.5em]
 z_{3,1} & z_{3,2}\\[0.5em]
 \end{bmatrix}
 &
+\nonumber
 \\
 &=
 \begin{bmatrix}
@@ -674,6 +686,7 @@ x_{1,1}.y_{1,1} & x_{1,2}.y_{1,2} \\[0.5em]
 x_{2,1}.y_{2,1} & x_{2,2}.y_{2,2} \\[0.5em]
 x_{3,1}.y_{3,1} & x_{3,2}.y_{3,2} \\[0.5em]
 \end{bmatrix}
+\nonumber
 \end{flalign}
 
 \subsection{Backward Pass}
@@ -687,6 +700,7 @@ We have $\frac{\partial L}{\partial \matr{Z}}$ of shape $3 \times 2$.
 \frac{\partial L}{\partial z_{3,1}} & \frac{\partial L}{\partial z_{3,2}} \\[0.5em]
 \end{bmatrix}
 & \eqncomment{$\frac{\partial L}{\partial \matr{Z}}$ is the same shape as $\matr{Z}$ as $L$ is a scalar}
+\label{dZ_hadamard_product}
 \end{flalign}
 
 \noindent We now need to compute $\frac{\partial L}{\partial \matr{X}}$ and $\frac{\partial L}{\partial \matr{Y}}$. Using chain rule, we get:
@@ -726,7 +740,7 @@ y_{1,1} & 0 & 0 & 0 & 0 & 0 \\[0.5em]
 \end{bmatrix}
 \end{flalign}
 
-\noindent Now, $\frac{\partial L}{\partial \matr{Z}}$ expressed as a column vector will be:
+\noindent Now, $\frac{\partial L}{\partial \matr{Z}}$ in equation \ref{dZ_hadamard_product} expressed as a column vector will be:
 
 \begin{flalign} \label{dZAsColumnVector_hadamard_product}
 \frac{\partial L}{\partial \matr{Z}} &=
@@ -917,6 +931,7 @@ x_{1,1} & x_{1,2} \\%[0.5em]
 x_{2,1} & x_{2,2} \\%[0.5em]
 x_{3,1} & x_{3,2} \\%[0.5em]
 \end{bmatrix} &
+\nonumber
 \end{flalign}
 
 \begin{flalign}
@@ -926,6 +941,7 @@ y_{1,1} & y_{1,2} \\%[0.5em]
 y_{2,1} & y_{2,2} \\%[0.5em]
 y_{3,1} & y_{3,2} \\%[0.5em]
 \end{bmatrix} &
+\nonumber
 \end{flalign}
 
 \noindent Given $\matr{Z} = \matr{X} + \matr{Y}$, Z is a $3 \times 2$ matrix which can be expressed as:
@@ -937,6 +953,7 @@ z_{2,1} & z_{2,2}\\[0.5em]
 z_{3,1} & z_{3,2}\\[0.5em]
 \end{bmatrix}
 &
+\nonumber
 \\
 &=
 \begin{bmatrix}
@@ -944,6 +961,7 @@ x_{1,1} + y_{1,1} & x_{1,2} + y_{1,2} \\[0.5em]
 x_{2,1} + y_{2,1} & x_{2,2} + y_{2,2} \\[0.5em]
 x_{3,1} + y_{3,1} & x_{3,2} + y_{3,2} \\[0.5em]
 \end{bmatrix}
+\nonumber
 \end{flalign}
 
 \subsection{Backward Pass}
@@ -957,6 +975,7 @@ We have $\frac{\partial L}{\partial \matr{Z}}$ of shape $3 \times 2$.
 \frac{\partial L}{\partial z_{3,1}} & \frac{\partial L}{\partial z_{3,2}} \\[0.5em]
 \end{bmatrix}
 & \eqncomment{$\frac{\partial L}{\partial \matr{Z}}$ is the same shape as $\matr{Z}$ as $L$ is a scalar}
+\label{dZ_matrix_addition}
 \end{flalign}
 
 \noindent We now need to compute $\frac{\partial L}{\partial \matr{X}}$ and $\frac{\partial L}{\partial \matr{Y}}$. Using chain rule, we get:
@@ -996,7 +1015,7 @@ To compute $\frac{\partial L}{\partial \matr{X}}$, we need to compute $\frac{\pa
 \end{bmatrix}
 \end{flalign}
 
-\noindent Now, $\frac{\partial L}{\partial \matr{Z}}$ expressed as a column vector will be:
+\noindent Now, $\frac{\partial L}{\partial \matr{Z}}$ in equation \ref{dZ_matrix_addition} expressed as a column vector will be:
 
 \begin{flalign} \label{dZAsColumnVector_matrix_addition}
 \frac{\partial L}{\partial \matr{Z}} &=
@@ -1156,6 +1175,7 @@ x_{1,1} & x_{1,2} \\%[0.5em]
 x_{2,1} & x_{2,2} \\%[0.5em]
 x_{3,1} & x_{3,2} \\%[0.5em]
 \end{bmatrix} &
+\nonumber
 \end{flalign}
 
 \noindent $\matr{Z}$ can be expressed as:
@@ -1172,6 +1192,7 @@ z_{2,1} & z_{2,2} & z_{2,3}\\%[0.5em]
 x_{1,1} & x_{2,1} & x_{3,1} \\%[0.5em]
 x_{1,2} & x_{2,2} & x_{3,2} \\%[0.5em]
 \end{bmatrix}
+\nonumber
 \end{flalign}
 
 \subsection{Backward Pass}
@@ -1184,6 +1205,7 @@ We have $\frac{\partial L}{\partial \matr{Z}}$ of shape $2 \times 3$.
 \frac{\partial L}{\partial z_{2,1}} & \frac{\partial L}{\partial z_{2,2}} & \frac{\partial L}{\partial z_{2,3}} \\[0.5em]
 \end{bmatrix}
 & \eqncomment{$\frac{\partial L}{\partial \matr{Z}}$ is the same shape as $\matr{Z}$ as $L$ is a scalar}
+\label{dZ_transpose}
 \end{flalign}
 
 \noindent We now need to compute $\frac{\partial L}{\partial \matr{X}}$. Using chain rule, we get:
@@ -1219,7 +1241,7 @@ To compute $\frac{\partial L}{\partial \matr{X}}$, we need to compute $\frac{\pa
 \end{bmatrix}
 \end{flalign}
 
-\noindent Now, $\frac{\partial L}{\partial \matr{Z}}$ expressed as a column vector will be:
+\noindent Now, $\frac{\partial L}{\partial \matr{Z}}$ in equation \ref{dZ_transpose} expressed as a column vector will be:
 
 \begin{flalign} \label{dZAsColumnVector_transpose}
 \frac{\partial L}{\partial \matr{Z}} &=
@@ -1307,6 +1329,7 @@ x_{1,1} & x_{1,2} \\%[0.5em]
 x_{2,1} & x_{2,2} \\%[0.5em]
 x_{3,1} & x_{3,2} \\%[0.5em]
 \end{bmatrix} &
+\nonumber
 \end{flalign}
 
 \noindent $\vecr{z}$ can be expressed as:
@@ -1323,6 +1346,7 @@ z_{1,1} & z_{1,2} \\%[0.5em]
 x_{1,1} + x_{2,1} + x_{3,1} &
 x_{1,2} + x_{2,2} + x_{3,2} \\%[0.5em]
 \end{bmatrix}
+\nonumber
 \end{flalign}
 
 \subsection{Backward Pass}
@@ -1334,6 +1358,7 @@ We have $\frac{\partial L}{\partial \vecr{z}}$ of shape $1 \times 2$.
 \frac{\partial L}{\partial z_{1,1}} & \frac{\partial L}{\partial z_{1,2}} \\[0.3em]
 \end{bmatrix}
 & \eqncomment{$\frac{\partial L}{\partial \vecr{z}}$ is the same shape as $\vecr{z}$ as $L$ is a scalar}
+\label{dZ_sum_along_axis_0}
 \end{flalign}
 
 \noindent We now need to compute $\frac{\partial L}{\partial \matr{X}}$. Using chain rule, we get:
@@ -1369,7 +1394,7 @@ To compute $\frac{\partial L}{\partial \matr{X}}$, we need to compute $\frac{\pa
 \end{bmatrix}
 \end{flalign}
 
-\noindent Now, $\frac{\partial L}{\partial \vecr{z}}$ expressed as a column vector will be:
+\noindent Now, $\frac{\partial L}{\partial \vecr{z}}$ in equation \ref{dZ_sum_along_axis_0} expressed as a column vector will be:
 
 \begin{flalign} \label{dZAsColumnVector_sum_along_axis_0}
 \frac{\partial L}{\partial \vecr{z}} &=
@@ -1458,6 +1483,7 @@ x_{1,1} & x_{1,2} \\%[0.5em]
 x_{2,1} & x_{2,2} \\%[0.5em]
 x_{3,1} & x_{3,2} \\%[0.5em]
 \end{bmatrix} &
+\nonumber
 \end{flalign}
 
 \noindent $\vecr{z}$ can be expressed as:
@@ -1477,6 +1503,7 @@ x_{1,1} + x_{1,2} \\
 x_{2,1} + x_{2,2} \\
 x_{3,1} + x_{3,2} \\
 \end{bmatrix}
+\nonumber
 \end{flalign}
 
 \subsection{Backward Pass}
@@ -1488,8 +1515,9 @@ We have $\frac{\partial L}{\partial \vecr{z}}$ of shape $3 \times 1$.
 \frac{\partial L}{\partial z_{1,1}} \\[0.7em]
 \frac{\partial L}{\partial z_{2,1}} \\[0.7em]
 \frac{\partial L}{\partial z_{3,1}} \\[0.7em]
-\end{bmatrix} \label{dZAsColumnVector_sum_along_axis_1}
+\end{bmatrix}
 & \eqncomment{$\frac{\partial L}{\partial \vecr{z}}$ is the same shape as $\vecr{z}$ as $L$ is a scalar}
+\label{dZAsColumnVector_sum_along_axis_1}
 \end{flalign}
 
 \noindent We now need to compute $\frac{\partial L}{\partial \matr{X}}$. Using chain rule, we get:
@@ -1605,6 +1633,7 @@ x_{1,1} \\%[0.5em]
 x_{2,1} \\%[0.5em]
 x_{3,1} \\%[0.5em]
 \end{bmatrix} &
+\nonumber
 \end{flalign}
 
 \noindent $\matr{Z}$ can be expressed as:
@@ -1624,6 +1653,7 @@ x_{1,1} & x_{1,1} \\
 x_{2,1} & x_{2,1} \\
 x_{3,1} & x_{3,1} \\
 \end{bmatrix}
+\nonumber
 \end{flalign}
 
 \subsection{Backward Pass}
@@ -1635,7 +1665,7 @@ We have $\frac{\partial L}{\partial \matr{Z}}$ of shape $3 \times 2$.
 \frac{\partial L}{\partial z_{1,1}} & \frac{\partial L}{\partial z_{1,2}} \\[0.7em]
 \frac{\partial L}{\partial z_{2,1}} & \frac{\partial L}{\partial z_{2,2}} \\[0.7em]
 \frac{\partial L}{\partial z_{3,1}} & \frac{\partial L}{\partial z_{3,2}} \\[0.7em]
-\end{bmatrix} \label{dZAsColumnVector_column_vector}
+\end{bmatrix} \label{dZ_broadcast_column_vector}
 & \eqncomment{$\frac{\partial L}{\partial \vecr{z}}$ is the same shape as $\vecr{z}$ as $L$ is a scalar}
 \end{flalign}
 
@@ -1666,7 +1696,7 @@ To compute $\frac{\partial L}{\partial \vecr{x}}$, we need to compute $\frac{\pa
 \end{bmatrix}
 \end{flalign}
 
-\noindent Now, $\frac{\partial L}{\partial \matr{Z}}$ expressed as a column vector will be:
+\noindent Now, $\frac{\partial L}{\partial \matr{Z}}$ in equation \ref{dZ_broadcast_column_vector} expressed as a column vector will be:
 
 \begin{flalign} \label{dZAsColumnVector_broadcast_column_vector}
 \frac{\partial L}{\partial \matr{Z}} &=
@@ -1751,6 +1781,7 @@ Suppose we are given a vector $\vecr{x}$ of shape $1 \times 3$. Let $\matr{Z} = 
 \begin{bmatrix}
 x_{1,1} & x_{1,2} & x_{1,3} \\%[0.5em]
 \end{bmatrix} &
+\nonumber
 \end{flalign}
 
 \noindent $\matr{Z}$ can be expressed as:
@@ -1768,6 +1799,7 @@ z_{2,1} & z_{2,2} & z_{2,3} \\
 x_{1,1} & x_{1,2} & x_{1,3} \\%[0.5em]
 x_{1,1} & x_{1,2} & x_{1,3} \\%[0.5em]
 \end{bmatrix}
+\nonumber
 \end{flalign}
 
 \subsection{Backward Pass}
@@ -1780,6 +1812,7 @@ We have $\frac{\partial L}{\partial \matr{Z}}$ of shape $2 \times 3$.
 \frac{\partial L}{\partial z_{2,1}} & \frac{\partial L}{\partial z_{2,2}} & \frac{\partial L}{\partial z_{2,3}}\\[0.7em]
 \end{bmatrix}
 & \eqncomment{$\frac{\partial L}{\partial \vecr{z}}$ is the same shape as $\vecr{z}$ as $L$ is a scalar}
+\label{dZ_broadcast_row_vector}
 \end{flalign}
 
 \noindent We now need to compute $\frac{\partial L}{\partial \vecr{x}}$. Using chain rule, we get:
@@ -1809,7 +1842,7 @@ To compute $\frac{\partial L}{\partial \vecr{x}}$, we need to compute $\frac{\pa
 \end{bmatrix}
 \end{flalign}
 
-\noindent Now, $\frac{\partial L}{\partial \matr{Z}}$ expressed as a column vector will be:
+\noindent Now, $\frac{\partial L}{\partial \matr{Z}}$ in equation \ref{dZ_broadcast_row_vector} expressed as a column vector will be:
 
 \begin{flalign} \label{dZAsColumnVector_broadcast_row_vector}
 \frac{\partial L}{\partial \matr{Z}} &=
@@ -1894,5 +1927,9 @@ To compute $\frac{\partial L}{\partial \vecr{x}}$, we need to compute $\frac{\pa
 \mathtt{np.sum(} \matr{Z} \mathtt{, axis=0)}
 & \eqncomment{Using $\mathtt{NumPy}$ notation for brevity}
 \end{flalign}
+
+\medskip
+
+\printbibliography
 
 \end{document}

--- a/student-contributions/BackPropagationBasicMatrixOperations.tex
+++ b/student-contributions/BackPropagationBasicMatrixOperations.tex
@@ -1,0 +1,1757 @@
+\documentclass{article}
+\usepackage[utf8]{inputenc}
+\usepackage{amsmath} % Required for display matrices.
+\usepackage{bm} % for rendering vectors correctly
+\usepackage{amssymb} % for rendering dimension symbol R
+\usepackage[nocfg,notintoc]{nomencl}
+\makenomenclature
+\usepackage{booktabs}
+%\renewcommand{\arraystretch}{2.0} % affects matrices too.
+\usepackage[letterpaper, margin=0.8in]{geometry}
+
+\renewcommand{\nomname}{} % We don't to use any word here.
+\newcommand{\transpose}[1]{#1^\top}
+\newcommand{\vecr}[1]{\bm{#1}}
+\newcommand{\matr}[1]{\mathbf{#1}} % undergraduate algebra version
+%\newcommand{\matr}[1]{#1}          % pure math version
+%\newcommand{\matr}[1]{\bm{#1}}     % ISO complying version
+
+\title{CS231N: Backpropagation - Basic Matrix Operations}
+\author{
+  Ashish Jain \\
+  Stanford University \\
+  \texttt{ashishj@stanford.edu}
+ }
+\date{\today}
+
+\begin{document}
+
+\maketitle
+
+\tableofcontents
+
+\section{Introduction}
+The intent of this document is to show using small non-trivial examples how and why certain backpropagation operations reduce to the equations they reduce to for basic operations such as matrix multiplication, some element-wise operation on a matrix, element-wise operations between two matrices and broadcasting of a vector to a matrix. The example matrices and vectors are deliberately kept small to ensure one can verify on paper if the contents of this document are correct.
+
+Each section from section \ref{Matrix Multiplication} onwards is written independently of each other, and therefore, you can directly jump to a section of your interest.
+
+\section{Nomenclature}
+\vspace{-2.5em}
+\nomenclature[N]{\(\vecr{x}\)}{Row or column vector}
+\nomenclature[N]{\(\matr{X}\)}{Two dimensional matrix}
+\nomenclature[N]{\(L\)}{Loss/Cost scalar}
+\nomenclature[N]{\(\mathbb{R}\)}{Real numbers}
+\nomenclature[O]{\(\mathrm{d}\text{Variable}\)}{$\frac{\partial L}{\partial \text{Variable}}$}
+
+\printnomenclature
+
+\section{Layout Convention}
+Given a vector $\vecr{y}$ where $\bm{y} \in \mathbb{R}^{m}$ and a vector $\bm{x}$ where $\bm{x} \in \mathbb{R}^{n}$, we are going to follow the \textbf{denominator layout} convention whereby $\frac{\partial y}{\partial x}$ is written as $n \times m$ matrix. This is in contrast to the \textbf{numerator layout} whereby $\frac{\partial y}{\partial x}$ is written as $m \times n$ matrix. 
+
+For example, if $\bm{x} \in \mathbb{R}^{3}$ and $\bm{y} \in \mathbb{R}^{2}$ then:
+
+\begin{displaymath}
+\frac{\partial \bm{y}}{\partial \bm{x}} = 
+\begin{bmatrix}
+\frac{\partial y_{1}}{\partial x_{1}} & \frac{\partial y_{2}}{\partial x_{1}} \\[0.5em]
+\frac{\partial y_{1}}{\partial x_{2}} & \frac{\partial y_{2}}{\partial x_{2}} \\[0.5em]
+\frac{\partial y_{1}}{\partial x_{3}} & \frac{\partial y_{2}}{\partial x_{3}} \\[0.5em]
+\end{bmatrix}
+\end{displaymath}
+
+\section{Summary}
+\small
+\begin{tabular}{cllll}
+\toprule
+Index & Name & $\matr{Z}$/$\vecr{z}$ & $\frac{\partial L}{\partial \matr{X}}$/$\frac{\partial L}{\partial \vecr{x}}$ & $\frac{\partial L}{\partial \matr{Y}}$/$\frac{\partial L}{\partial \vecr{y}}$ \\[0.3em]
+
+\midrule
+
+1 & Matrix Multiplication & $\matr{Z} = \matr{X}\matr{Y}$ &
+$\frac{\partial L}{\partial \matr{X}}=\frac{\partial L}{\partial \matr{Z}} \transpose{\matr{Y}}$ &
+$\frac{\partial L}{\partial \matr{Y}}=\transpose{\matr{X}} \frac{\partial L}{\partial \matr{Z}}$ \\[1em]
+
+2 & Element-wise function & $\matr{Z} = g(\matr{X})$ &
+$\frac{\partial L}{\partial \matr{X}}=g'(\matr{X}) \circ \frac{\partial L}{\partial \matr{Z}}$ & \\[1em]
+
+3 & Hadamard Product & $\matr{Z} = \matr{X} \circ \matr{Y}$ &
+$\frac{\partial L}{\partial \matr{X}}=\matr{Y} \circ \frac{\partial L}{\partial \matr{Z}}$ &
+$\frac{\partial L}{\partial \matr{Y}}=\matr{X} \circ \frac{\partial L}{\partial \matr{Z}}$ \\[1em]
+
+4 & Matrix Addition & $\matr{Z} = \matr{X} + \matr{Y}$ &
+$\frac{\partial L}{\partial \matr{X}}=\frac{\partial L}{\partial \matr{Z}}$ &
+$\frac{\partial L}{\partial \matr{Y}}=\frac{\partial L}{\partial \matr{Z}}$\\[1em]
+
+5 & Transpose & $\matr{Z} = \transpose{\matr{X}}$ &
+$\frac{\partial L}{\partial \matr{X}}=\transpose{\frac{\partial L}{\partial \matr{Z}}}$ & \\[1em]
+
+6 & Sum along axis=0 & $\vecr{z}$ = \verb|np.sum(|${\matr{X}}$\verb|, axis=0)| &
+$\frac{\partial L}{\partial \matr{X}}=\mathbf{1}_{\text{rows}(\matr{X}),1} \frac{\partial L}{\partial \vecr{z}}$ & \\[1em]
+
+7 & Sum along axis=1 & $\vecr{z}$ = \verb|np.sum(|${\matr{X}}$\verb|, axis=1)| &
+$\frac{\partial L}{\partial \matr{X}}=\frac{\partial L}{\partial \vecr{z}} \mathbf{1}_{1, \text{cols}(\matr{X})}$ & \\[1em]
+
+8 & Broadcasting a column vector & $\matr{Z} = \vecr{x} \mathbf{1}_{1,\text{C}}$ &
+$\frac{\partial L}{\partial \vecr{x}}=\mathtt{np.sum(} \frac{\partial L}{\partial \matr{Z}} \mathtt{, axis=1)}$ & \\[1em]
+
+9 & Broadcasting a row vector & $\matr{Z} = \mathbf{1}_{\text{R},1} \vecr{x}$ &
+$\frac{\partial L}{\partial \vecr{x}}=\mathtt{np.sum(} \frac{\partial L}{\partial \matr{Z}} \mathtt{, axis=0)}$ & \\[1em]
+\bottomrule
+\end{tabular}
+
+\normalsize
+
+\section{NumPy}
+\footnotesize
+\begin{tabular}{cllll}
+\toprule
+Index & Name & $\matr{Z}$/$\vecr{z}$ &
+\verb dX  = $\frac{\partial L}{\partial \matr{X}}$/ \verb dx  = $\frac{\partial L}{\partial \vecr{x}}$ &
+\verb dY  = $\frac{\partial L}{\partial \matr{Y}}$/ \verb dy  = $\frac{\partial L}{\partial \vecr{y}}$ \\[0.3em]
+
+\midrule
+1 & Matrix Multiplication & \verb Z  = \verb X@Y &
+\verb dX  = \verb dZ@Y.T &
+\verb dY  = \verb X.T@dZ \\[0.7em]
+
+2 & Element-wise function & \verb Z  = \verb g(X) &
+\verb dX  = \verb g'(X) *\verb dZ & \\[0.7em]
+
+3 & Hadamard Product & \verb Z  = \verb X*Y &
+\verb dX  = \verb Y*dZ &
+\verb dY  = \verb X*dZ \\[0.7em]
+
+4 & Matrix Addition & \verb Z  = \verb X+Y &
+\verb dX  = \verb dZ &
+\verb dY  = \verb dZ \\[0.7em]
+
+5 & Transpose & \verb Z  = \verb X.T &
+\verb dX  = \verb dZ.T & \\[0.7em]
+
+6 & Sum along axis=0 & \verb z  = \verb|np.sum(X,axis=0)| &
+\verb dX  = \verb|np.ones((X.shape[0],1))@dz| & \\[0.7em]
+
+7 & Sum along axis=1 & \verb z  = \verb|np.sum(X,axis=1)| &
+\verb dX  = \verb|dz@np.ones((1,X.shape[1]))| & \\[0.7em]
+
+8 & Broadcasting a column vector & \verb Z  = \verb|x+np.zeros((1,C))| &
+\verb dx  = \verb|np.sum(dZ,axis=1)| & \\[0.7em]
+
+9 & Broadcasting a row vector & \verb Z  = \verb|x+np.zeros((R,1))| &
+\verb dx  = \verb|np.sum(dZ,axis=0)| & \\[0.3em]
+\bottomrule
+\end{tabular}
+
+\normalsize
+\section{Matrix Multiplication} \label{Matrix Multiplication}
+\subsection{Forward Pass}
+Let $\matr{X}$ be a $2 \times 3$ matrix, and let $\matr{Y}$ be a $3 \times 2$ matrix. Let $\matr{Z} = \matr{X}\matr{Y}$. $\matr{Z}$ will be of shape $2 \times 2$.
+
+\begin{displaymath}
+\matr{X} =
+\begin{bmatrix}
+x_{1,1} & x_{1,2} & x_{1,3} \\%[0.5em]
+x_{2,1} & x_{2,2} & x_{2,3} \\%[0.5em]
+\end{bmatrix}
+\end{displaymath}
+
+\begin{displaymath}
+\matr{Y} =
+\begin{bmatrix}
+y_{1,1} & y_{1,2} \\%[0.5em]
+y_{2,1} & y_{2,2} \\%[0.5em]
+y_{3,1} & y_{3,2} \\%[0.5em]
+\end{bmatrix}
+\end{displaymath}
+
+Given $\matr{Z} = \matr{X}\matr{Y}$, Z is a $2 \times 2$ matrix which can be expressed as:
+
+\begin{align}
+\matr{Z} &= \begin{bmatrix}
+z_{1,1} & z_{1,2}\\[0.5em]
+z_{2,1} & z_{2,2}\\[0.5em]
+\end{bmatrix}
+\\
+&=
+\begin{bmatrix}
+x_{1,1}.y_{1,1} + x_{1,2}.y_{2,1} + x_{1,3}.y_{3,1} & x_{1,1}.y_{1,2} + x_{1,2}.y_{2,2} + x_{1,3}.y_{3,2}\\[0.5em]
+x_{2,1}.y_{1,1} + x_{2,2}.y_{2,1} + x_{2,3}.y_{3,1} & x_{2,1}.y_{1,2} + x_{2,2}.y_{2,2} + x_{2,3}.y_{3,2}\\[0.5em]
+\end{bmatrix}
+\end{align}
+
+\subsection{Backward Pass}
+We have $\frac{\partial L}{\partial \matr{Z}}$ of shape $2 \times 2$.
+
+\begin{displaymath}
+\frac{\partial L}{\partial \matr{Z}} =
+\begin{bmatrix}
+\frac{\partial L}{\partial z_{1,1}} & \frac{\partial L}{\partial z_{1,2}} \\[0.5em]
+\frac{\partial L}{\partial z_{2,1}} & \frac{\partial L}{\partial z_{2,2}} \\[0.5em]
+\end{bmatrix}
+\end{displaymath}
+
+We now need to compute $\frac{\partial L}{\partial \matr{X}}$ and $\frac{\partial L}{\partial \matr{Y}}$. Using chain rule, we get:
+
+\begin{equation} \label{dX}
+\frac{\partial L}{\partial \matr{X}} = \frac{\partial \matr{Z}}{\partial \matr{X}}\frac{\partial L}{\partial \matr{Z}}
+\end{equation}
+
+\begin{equation} \label{dY}
+\frac{\partial L}{\partial \matr{Y}} = \frac{\partial \matr{Z}}{\partial \matr{Y}}\frac{\partial L}{\partial \matr{Z}}
+\end{equation}
+
+\subsubsection{Computing $\frac{\partial L}{\partial \matr{X}}$}
+To compute $\frac{\partial L}{\partial \matr{X}}$, we need to compute $\frac{\partial \matr{Z}}{\partial \matr{X}}$. To make it easy for us to think about and capture the Jacobian in a two dimensional matrix (as opposed to a tensor), we will reshape matrices $\matr{X}$, $\matr{Y}$ and $\matr{Z}$ as column vectors, and compute Jacobians on them. Once we have computed the column vector corresponding to $\frac{\partial L}{\partial \matr{X}}$, we will reshape it back to a matrix with the same shape as $\matr{X}$.
+
+\begin{align}
+\frac{\partial \matr{Z}}{\partial \matr{X}} &=
+\begin{bmatrix}
+\frac{\partial z_{1,1}}{\partial x_{1,1}} & \frac{\partial z_{1,2}}{\partial x_{1,1}} & \frac{\partial z_{2,1}}{\partial x_{1,1}} & \frac{\partial z_{2,2}}{\partial x_{1,1}} \\[0.5em]
+\frac{\partial z_{1,1}}{\partial x_{1,2}} & \frac{\partial z_{1,2}}{\partial x_{1,2}} & \frac{\partial z_{2,1}}{\partial x_{1,2}} & \frac{\partial z_{2,2}}{\partial x_{1,2}} \\[0.5em]
+\frac{\partial z_{1,1}}{\partial x_{1,3}} & \frac{\partial z_{1,2}}{\partial x_{1,3}} & \frac{\partial z_{2,1}}{\partial x_{1,3}} & \frac{\partial z_{2,2}}{\partial x_{1,3}} \\[0.5em]
+\frac{\partial z_{1,1}}{\partial x_{2,1}} & \frac{\partial z_{1,2}}{\partial x_{2,1}} & \frac{\partial z_{2,1}}{\partial x_{2,1}} & \frac{\partial z_{2,2}}{\partial x_{2,1}} \\[0.5em]
+\frac{\partial z_{1,1}}{\partial x_{2,2}} & \frac{\partial z_{1,2}}{\partial x_{2,2}} & \frac{\partial z_{2,1}}{\partial x_{2,2}} & \frac{\partial z_{2,2}}{\partial x_{2,2}} \\[0.5em]
+\frac{\partial z_{1,1}}{\partial x_{2,3}} & \frac{\partial z_{1,2}}{\partial x_{2,3}} & \frac{\partial z_{2,1}}{\partial x_{2,3}} & \frac{\partial z_{2,2}}{\partial x_{2,3}} \\[0.5em]
+\end{bmatrix} \nonumber
+\\ \label{dZbydX}
+&=
+\begin{bmatrix}
+y_{1,1} & y_{1,2} & 0 & 0 \\[0.5em]
+y_{2,1} & y_{2,2} & 0 & 0 \\[0.5em]
+y_{3,1} & y_{3,2} & 0 & 0 \\[0.5em]
+0 & 0 & y_{1,1} & y_{1,2} \\[0.5em]
+0 & 0 & y_{2,1} & y_{2,2} \\[0.5em]
+0 & 0 & y_{3,1} & y_{3,2} \\[0.5em]
+\end{bmatrix}
+\end{align}
+
+Now, $\frac{\partial L}{\partial \matr{Z}}$ expressed as a column vector will be:
+
+\begin{equation} \label{dZAsColumnVector}
+\frac{\partial L}{\partial \matr{Z}} =
+\begin{bmatrix}
+\frac{\partial L}{\partial z_{1,1}} \\[0.7em]
+\frac{\partial L}{\partial z_{1,2}} \\[0.7em]
+\frac{\partial L}{\partial z_{2,1}} \\[0.7em]
+\frac{\partial L}{\partial z_{2,2}} \\[0.7em]
+\end{bmatrix}
+\end{equation}
+
+Plugging equations \ref{dZbydX} and \ref{dZAsColumnVector} into equation \ref{dX}, we get:
+
+\begin{align}
+\frac{\partial L}{\partial \matr{X}} &=
+\begin{bmatrix}
+y_{1,1} & y_{1,2} & 0 & 0 \\[0.5em]
+y_{2,1} & y_{2,2} & 0 & 0 \\[0.5em]
+y_{3,1} & y_{3,2} & 0 & 0 \\[0.5em]
+0 & 0 & y_{1,1} & y_{1,2} \\[0.5em]
+0 & 0 & y_{2,1} & y_{2,2} \\[0.5em]
+0 & 0 & y_{3,1} & y_{3,2} \\[0.5em]
+\end{bmatrix}
+\begin{bmatrix}
+\frac{\partial L}{\partial z_{1,1}} \\[0.7em]
+\frac{\partial L}{\partial z_{1,2}} \\[0.7em]
+\frac{\partial L}{\partial z_{2,1}} \\[0.7em]
+\frac{\partial L}{\partial z_{2,2}} \\[0.7em]
+\end{bmatrix}
+\nonumber \\ 
+&= 
+\begin{bmatrix}
+y_{1,1}.\frac{\partial L}{\partial z_{1,1}} + y_{1,2}.\frac{\partial L}{\partial z_{1,2}} \\[0.7em]
+y_{2,1}.\frac{\partial L}{\partial z_{1,1}} + y_{2,2}.\frac{\partial L}{\partial z_{1,2}} \\[0.7em]
+y_{3,1}.\frac{\partial L}{\partial z_{1,1}} + y_{3,2}.\frac{\partial L}{\partial z_{1,2}} \\[0.7em]
+y_{1,1}.\frac{\partial L}{\partial z_{2,1}} + y_{1,2}.\frac{\partial L}{\partial z_{2,2}} \\[0.7em]
+y_{2,1}.\frac{\partial L}{\partial z_{2,1}} + y_{2,2}.\frac{\partial L}{\partial z_{2,2}} \\[0.7em]
+y_{3,1}.\frac{\partial L}{\partial z_{2,1}} + y_{3,2}.\frac{\partial L}{\partial z_{2,2}} \\[0.7em]
+\end{bmatrix} \label{dXAsColumnVector}
+\end{align}
+
+Reshaping column vector in equation \ref{dXAsColumnVector} as a matrix of shape $\matr{X}$, we get:
+\begin{align}
+\frac{\partial L}{\partial \matr{X}} &=
+\begin{bmatrix}
+y_{1,1}.\frac{\partial L}{\partial z_{1,1}} + y_{1,2}.\frac{\partial L}{\partial z_{1,2}} &
+y_{2,1}.\frac{\partial L}{\partial z_{1,1}} + y_{2,2}.\frac{\partial L}{\partial z_{1,2}} &
+y_{3,1}.\frac{\partial L}{\partial z_{1,1}} + y_{3,2}.\frac{\partial L}{\partial z_{1,2}} \\[0.7em]
+y_{1,1}.\frac{\partial L}{\partial z_{2,1}} + y_{1,2}.\frac{\partial L}{\partial z_{2,2}} &
+y_{2,1}.\frac{\partial L}{\partial z_{2,1}} + y_{2,2}.\frac{\partial L}{\partial z_{2,2}} &
+y_{3,1}.\frac{\partial L}{\partial z_{2,1}} + y_{3,2}.\frac{\partial L}{\partial z_{2,2}} \\[0.7em]
+\end{bmatrix}
+\nonumber \\ 
+&=
+\begin{bmatrix}
+\frac{\partial L}{\partial z_{1,1}} & \frac{\partial L}{\partial z_{1,2}} \\[0.7em]
+\frac{\partial L}{\partial z_{2,1}} & \frac{\partial L}{\partial z_{2,2}} \\[0.7em]
+\end{bmatrix}
+\begin{bmatrix}
+y_{1,1} & y_{2,1} & y_{3,1} \\%[0.5em]
+y_{1,2} & y_{2,2} & y_{3,2} \\%[0.5em]
+\end{bmatrix}
+\nonumber \\
+&=
+\begin{bmatrix}
+\frac{\partial L}{\partial z_{1,1}} & \frac{\partial L}{\partial z_{1,2}} \\[0.7em]
+\frac{\partial L}{\partial z_{2,1}} & \frac{\partial L}{\partial z_{2,2}} \\[0.7em]
+\end{bmatrix}
+\transpose{\begin{bmatrix}
+y_{1,1} & y_{1,2} \\%[0.5em]
+y_{2,1} & y_{2,2} \\%[0.5em]
+y_{3,1} & y_{3,2} \\%[0.5em]
+\end{bmatrix}}
+\nonumber \\ \label{dXFinal}
+&= \frac{\partial L}{\partial \matr{Z}} \transpose{\matr{Y}}
+\end{align}
+
+\subsubsection{Computing $\frac{\partial L}{\partial \matr{Y}}$}
+To compute $\frac{\partial L}{\partial \matr{Y}}$, we need to compute $\frac{\partial \matr{Z}}{\partial \matr{Y}}$. To make it easy for us to think about and capture the Jacobian in a two dimensional matrix (as opposed to a tensor), we will reshape matrices $\matr{X}$, $\matr{Y}$ and $\matr{Z}$ as column vectors, and compute Jacobians on them. Once we have computed the column vector corresponding to $\frac{\partial L}{\partial \matr{Y}}$, we will reshape it back to a matrix with the same shape as $\matr{Y}$.
+
+\begin{align}
+\frac{\partial \matr{Z}}{\partial \matr{Y}} &=
+\begin{bmatrix}
+\frac{\partial z_{1,1}}{\partial y_{1,1}} & \frac{\partial z_{1,2}}{\partial y_{1,1}} & \frac{\partial z_{2,1}}{\partial y_{1,1}} & \frac{\partial z_{2,2}}{\partial y_{1,1}} \\[0.5em]
+\frac{\partial z_{1,1}}{\partial y_{1,2}} & \frac{\partial z_{1,2}}{\partial y_{1,2}} & \frac{\partial z_{2,1}}{\partial y_{1,2}} & \frac{\partial z_{2,2}}{\partial y_{1,2}} \\[0.5em]
+\frac{\partial z_{1,1}}{\partial y_{2,1}} & \frac{\partial z_{1,2}}{\partial y_{2,1}} & \frac{\partial z_{2,1}}{\partial y_{2,1}} & \frac{\partial z_{2,2}}{\partial y_{2,1}} \\[0.5em]
+\frac{\partial z_{1,1}}{\partial y_{2,2}} & \frac{\partial z_{1,2}}{\partial y_{2,2}} & \frac{\partial z_{2,1}}{\partial y_{2,2}} & \frac{\partial z_{2,2}}{\partial y_{2,2}} \\[0.5em]
+\frac{\partial z_{1,1}}{\partial y_{3,1}} & \frac{\partial z_{1,2}}{\partial y_{3,1}} & \frac{\partial z_{2,1}}{\partial y_{3,1}} & \frac{\partial z_{2,2}}{\partial y_{3,1}} \\[0.5em]
+\frac{\partial z_{1,1}}{\partial y_{3,2}} & \frac{\partial z_{1,2}}{\partial y_{3,2}} & \frac{\partial z_{2,1}}{\partial y_{3,2}} & \frac{\partial z_{2,2}}{\partial y_{3,2}} \\[0.5em]
+\end{bmatrix} \nonumber
+\\
+&=
+\begin{bmatrix}
+x_{1,1} & 0 & x_{2,1} & 0 \\[0.5em]
+0 & x_{1,1} & 0 & x_{2,1} \\[0.5em]
+x_{1,2} & 0 & x_{2,2} & 0 \\[0.5em]
+0 & x_{1,2} & 0 & x_{2,2} \\[0.5em]
+x_{1,3} & 0 & x_{2,3} & 0 \\[0.5em]
+0 & x_{1,3} & 0 & x_{2,3} \\[0.5em]
+\end{bmatrix} \label{dZbydY}
+\end{align}
+
+Plugging equations \ref{dZbydY} and \ref{dZAsColumnVector} into equation \ref{dY}, we get:
+
+\begin{align}
+\frac{\partial L}{\partial \matr{Y}} &=
+\begin{bmatrix}
+x_{1,1} & 0 & x_{2,1} & 0 \\[0.5em]
+0 & x_{1,1} & 0 & x_{2,1} \\[0.5em]
+x_{1,2} & 0 & x_{2,2} & 0 \\[0.5em]
+0 & x_{1,2} & 0 & x_{2,2} \\[0.5em]
+x_{1,3} & 0 & x_{2,3} & 0 \\[0.5em]
+0 & x_{1,3} & 0 & x_{2,3} \\[0.5em]
+\end{bmatrix}
+\begin{bmatrix}
+\frac{\partial L}{\partial z_{1,1}} \\[0.7em]
+\frac{\partial L}{\partial z_{1,2}} \\[0.7em]
+\frac{\partial L}{\partial z_{2,1}} \\[0.7em]
+\frac{\partial L}{\partial z_{2,2}} \\[0.7em]
+\end{bmatrix}
+\nonumber \\
+&=
+\begin{bmatrix}
+x_{1,1}.\frac{\partial L}{\partial z_{1,1}} + x_{2,1}.\frac{\partial L}{\partial z_{2,1}} \\[0.7em]
+x_{1,1}.\frac{\partial L}{\partial z_{1,2}} + x_{2,1}.\frac{\partial L}{\partial z_{2,2}} \\[0.7em]
+x_{1,2}.\frac{\partial L}{\partial z_{1,1}} + x_{2,2}.\frac{\partial L}{\partial z_{2,1}} \\[0.7em]
+x_{1,2}.\frac{\partial L}{\partial z_{1,2}} + x_{2,2}.\frac{\partial L}{\partial z_{2,2}} \\[0.7em]
+x_{1,3}.\frac{\partial L}{\partial z_{1,1}} + x_{2,3}.\frac{\partial L}{\partial z_{2,1}} \\[0.7em]
+x_{1,3}.\frac{\partial L}{\partial z_{1,2}} + x_{2,3}.\frac{\partial L}{\partial z_{2,2}} \\[0.7em]
+\end{bmatrix} \label{dYAsColumnVector}
+\end{align}
+
+Reshaping column vector in equation \ref{dYAsColumnVector} as a matrix of shape $\matr{Y}$, we get:
+
+\begin{align}
+\frac{\partial L}{\partial \matr{Y}} &=
+\begin{bmatrix}
+x_{1,1}.\frac{\partial L}{\partial z_{1,1}} + x_{2,1}.\frac{\partial L}{\partial z_{2,1}} &
+x_{1,1}.\frac{\partial L}{\partial z_{1,2}} + x_{2,1}.\frac{\partial L}{\partial z_{2,2}} \\[0.7em]
+x_{1,2}.\frac{\partial L}{\partial z_{1,1}} + x_{2,2}.\frac{\partial L}{\partial z_{2,1}} &
+x_{1,2}.\frac{\partial L}{\partial z_{1,2}} + x_{2,2}.\frac{\partial L}{\partial z_{2,2}} \\[0.7em]
+x_{1,3}.\frac{\partial L}{\partial z_{1,1}} + x_{2,3}.\frac{\partial L}{\partial z_{2,1}} &
+x_{1,3}.\frac{\partial L}{\partial z_{1,2}} + x_{2,3}.\frac{\partial L}{\partial z_{2,2}} \\[0.7em]
+\end{bmatrix}
+\nonumber \\
+&=
+\begin{bmatrix}
+x_{1,1} & x_{2,1} \\%[0.5em]
+x_{1,2} & x_{2,2} \\%[0.5em]
+x_{1,3} & x_{2,3} \\%[0.5em]
+\end{bmatrix}
+\begin{bmatrix}
+\frac{\partial L}{\partial z_{1,1}} & \frac{\partial L}{\partial z_{1,2}} \\[0.7em]
+\frac{\partial L}{\partial z_{2,1}} & \frac{\partial L}{\partial z_{2,2}} \\[0.7em]
+\end{bmatrix}
+\nonumber \\
+&=
+\transpose{
+\begin{bmatrix}
+x_{1,1} & x_{1,2} & x_{1,3} \\%[0.5em]
+x_{2,1} & x_{2,2} & x_{2,3} \\%[0.5em]
+\end{bmatrix}}
+\begin{bmatrix}
+\frac{\partial L}{\partial z_{1,1}} & \frac{\partial L}{\partial z_{1,2}} \\[0.7em]
+\frac{\partial L}{\partial z_{2,1}} & \frac{\partial L}{\partial z_{2,2}} \\[0.7em]
+\end{bmatrix}
+\nonumber \\
+&= \transpose{\matr{X}} \frac{\partial L}{\partial \matr{Z}}
+\end{align}
+
+\section{Element-wise operation on a Matrix}
+\subsection{Forward Pass}
+Consider some function $g(x)$ which is applied element-wise on a matrix $\matr{X}$ of shape $3 \times 2$. Let $\matr{Z} = g(\matr{X})$. $\matr{Z}$ will be of shape $3 \times 2$.
+
+\begin{displaymath}
+\matr{X} =
+\begin{bmatrix}
+x_{1,1} & x_{1,2} \\%[0.5em]
+x_{2,1} & x_{2,2} \\%[0.5em]
+x_{3,1} & x_{3,2} \\%[0.5em]
+\end{bmatrix}
+\end{displaymath}
+
+$\matr{Z}$ can be expressed as:
+
+\begin{align}
+\matr{Z} &=
+\begin{bmatrix}
+z_{1,1} & z_{1,2} \\%[0.5em]
+z_{2,1} & z_{2,2} \\%[0.5em]
+z_{3,1} & z_{3,2} \\%[0.5em]
+\end{bmatrix}
+\nonumber \\
+&=
+\begin{bmatrix}
+g(x_{1,1}) & g(x_{1,2}) \\[0.5em]
+g(x_{2,1}) & g(x_{2,2}) \\[0.5em]
+g(x_{3,1}) & g(x_{3,2}) \\[0.5em]
+\end{bmatrix}
+\end{align}
+
+\subsection{Backward Pass}
+We have $\frac{\partial L}{\partial \matr{Z}}$ of shape $3 \times 2$.
+
+\begin{displaymath}
+\frac{\partial L}{\partial \matr{Z}} =
+\begin{bmatrix}
+\frac{\partial L}{\partial z_{1,1}} & \frac{\partial L}{\partial z_{1,2}} \\[0.5em]
+\frac{\partial L}{\partial z_{2,1}} & \frac{\partial L}{\partial z_{2,2}} \\[0.5em]
+\frac{\partial L}{\partial z_{3,1}} & \frac{\partial L}{\partial z_{3,2}} \\[0.5em]
+\end{bmatrix}
+\end{displaymath}
+
+We now need to compute $\frac{\partial L}{\partial \matr{X}}$. Using chain rule, we get:
+
+\begin{equation} \label{dX_elewise_single_matrix}
+\frac{\partial L}{\partial \matr{X}} = \frac{\partial \matr{Z}}{\partial \matr{X}}\frac{\partial L}{\partial \matr{Z}}
+\end{equation}
+
+\subsubsection{Computing $\frac{\partial L}{\partial \matr{X}}$}
+To compute $\frac{\partial L}{\partial \matr{X}}$, we need to compute $\frac{\partial \matr{Z}}{\partial \matr{X}}$. To make it easy for us to think about and capture the Jacobian in a two dimensional matrix (as opposed to a tensor), we will reshape matrices $\matr{X}$ and $\matr{Z}$ as column vectors, and compute Jacobians on them. Once we have computed the column vector corresponding to $\frac{\partial L}{\partial \matr{X}}$, we will reshape it back to a matrix with the same shape as $\matr{X}$.
+
+\begin{align}
+\frac{\partial \matr{Z}}{\partial \matr{X}} &=
+\begin{bmatrix}
+\frac{\partial z_{1,1}}{\partial x_{1,1}} & \frac{\partial z_{1,2}}{\partial x_{1,1}} & \frac{\partial z_{2,1}}{\partial x_{1,1}} & \frac{\partial z_{2,2}}{\partial x_{1,1}} & \frac{\partial z_{3,1}}{\partial x_{1,1}} & \frac{\partial z_{3,2}}{\partial x_{1,1}}\\[0.7em]
+\frac{\partial z_{1,1}}{\partial x_{1,2}} & \frac{\partial z_{1,2}}{\partial x_{1,2}} & \frac{\partial z_{2,1}}{\partial x_{1,2}} & \frac{\partial z_{2,2}}{\partial x_{1,2}} & \frac{\partial z_{3,1}}{\partial x_{1,2}} & \frac{\partial z_{3,2}}{\partial x_{1,2}}\\[0.7em]
+\frac{\partial z_{1,1}}{\partial x_{2,1}} & \frac{\partial z_{1,2}}{\partial x_{2,1}} & \frac{\partial z_{2,1}}{\partial x_{2,1}} & \frac{\partial z_{2,2}}{\partial x_{2,1}} & \frac{\partial z_{3,1}}{\partial x_{2,1}} & \frac{\partial z_{3,2}}{\partial x_{2,1}}\\[0.7em]
+\frac{\partial z_{1,1}}{\partial x_{2,2}} & \frac{\partial z_{1,2}}{\partial x_{2,2}} & \frac{\partial z_{2,1}}{\partial x_{2,2}} & \frac{\partial z_{2,2}}{\partial x_{2,2}} & \frac{\partial z_{3,1}}{\partial x_{2,2}} & \frac{\partial z_{3,2}}{\partial x_{2,2}}\\[0.7em]
+\frac{\partial z_{1,1}}{\partial x_{3,1}} & \frac{\partial z_{1,2}}{\partial x_{3,1}} & \frac{\partial z_{2,1}}{\partial x_{3,1}} & \frac{\partial z_{2,2}}{\partial x_{3,1}} & \frac{\partial z_{3,1}}{\partial x_{3,1}} & \frac{\partial z_{3,2}}{\partial x_{3,1}}\\[0.7em]
+\frac{\partial z_{1,1}}{\partial x_{3,2}} & \frac{\partial z_{1,2}}{\partial x_{3,2}} & \frac{\partial z_{2,1}}{\partial x_{3,2}} & \frac{\partial z_{2,2}}{\partial x_{3,2}} & \frac{\partial z_{3,1}}{\partial x_{3,2}} & \frac{\partial z_{3,2}}{\partial x_{3,2}}\\[0.7em]
+\end{bmatrix} \nonumber
+\\ \label{dZbydX_elewise_single_matrix}
+&=
+\begin{bmatrix}
+g'(x_{1,1}) & 0 & 0 & 0 & 0 & 0 \\[0.5em]
+0 & g'(x_{1,2}) & 0 & 0 & 0 & 0 \\[0.5em]
+0 & 0 & g'(x_{2,1}) & 0 & 0 & 0 \\[0.5em]
+0 & 0 & 0 & g'(x_{2,2}) & 0 & 0 \\[0.5em]
+0 & 0 & 0 & 0 & g'(x_{3,1}) & 0 \\[0.5em]
+0 & 0 & 0 & 0 & 0 & g'(x_{3,2}) \\[0.5em]
+\end{bmatrix}
+\end{align}
+
+Now, $\frac{\partial L}{\partial \matr{Z}}$ expressed as a column vector will be:
+
+\begin{equation} \label{dZAsColumnVector_elewise_single_matrix}
+\frac{\partial L}{\partial \matr{Z}} =
+\begin{bmatrix}
+\frac{\partial L}{\partial z_{1,1}} \\[0.7em]
+\frac{\partial L}{\partial z_{1,2}} \\[0.7em]
+\frac{\partial L}{\partial z_{2,1}} \\[0.7em]
+\frac{\partial L}{\partial z_{2,2}} \\[0.7em]
+\frac{\partial L}{\partial z_{3,1}} \\[0.7em]
+\frac{\partial L}{\partial z_{3,2}} \\[0.7em]
+\end{bmatrix}
+\end{equation}
+
+
+Plugging equations \ref{dZbydX_elewise_single_matrix} and \ref{dZAsColumnVector_elewise_single_matrix} into equation \ref{dX_elewise_single_matrix}, we get:
+
+\begin{align}
+\frac{\partial L}{\partial \matr{X}} &=
+\begin{bmatrix}
+g'(x_{1,1}) & 0 & 0 & 0 & 0 & 0 \\[0.5em]
+0 & g'(x_{1,2}) & 0 & 0 & 0 & 0 \\[0.5em]
+0 & 0 & g'(x_{2,1}) & 0 & 0 & 0 \\[0.5em]
+0 & 0 & 0 & g'(x_{2,2}) & 0 & 0 \\[0.5em]
+0 & 0 & 0 & 0 & g'(x_{3,1}) & 0 \\[0.5em]
+0 & 0 & 0 & 0 & 0 & g'(x_{3,2}) \\[0.5em]
+\end{bmatrix}
+\begin{bmatrix}
+\frac{\partial L}{\partial z_{1,1}} \\[0.7em]
+\frac{\partial L}{\partial z_{1,2}} \\[0.7em]
+\frac{\partial L}{\partial z_{2,1}} \\[0.7em]
+\frac{\partial L}{\partial z_{2,2}} \\[0.7em]
+\frac{\partial L}{\partial z_{3,1}} \\[0.7em]
+\frac{\partial L}{\partial z_{3,2}} \\[0.7em]
+\end{bmatrix}
+\nonumber \\
+&=
+\begin{bmatrix}
+g'(x_{1,1}).\frac{\partial L}{\partial z_{1,1}} \\[0.7em]
+g'(x_{1,2}).\frac{\partial L}{\partial z_{1,2}} \\[0.7em]
+g'(x_{2,1}).\frac{\partial L}{\partial z_{2,1}} \\[0.7em]
+g'(x_{2,2}).\frac{\partial L}{\partial z_{2,2}} \\[0.7em]
+g'(x_{3,1}).\frac{\partial L}{\partial z_{3,1}} \\[0.7em]
+g'(x_{3,2}).\frac{\partial L}{\partial z_{3,2}} \\[0.7em]
+\end{bmatrix} \label{dXAsColumnVector_elewise_single_matrix}
+\end{align}
+
+Note, we will be using $\circ$ to denote Hadamard product. Also $g'(\matr{X})$ like $g(\matr{X})$ will be applied element-wise.
+
+\begin{align}
+g'(\matr{X}) &=
+\begin{bmatrix}
+g'(x_{1,1}) & g'(x_{1,2}) \\[0.5em]
+g'(x_{2,1}) & g'(x_{2,2}) \\[0.5em]
+g'(x_{3,1}) & g'(x_{3,2}) \\[0.5em]
+\end{bmatrix} \nonumber
+\end{align}
+
+Now, reshaping column vector in equation \ref{dXAsColumnVector_elewise_single_matrix} as a matrix of shape $\matr{X}$, we get:
+
+\begin{align}
+\frac{\partial L}{\partial \matr{X}} &=
+\begin{bmatrix}
+g'(x_{1,1}).\frac{\partial L}{\partial z_{1,1}} &
+g'(x_{1,2}).\frac{\partial L}{\partial z_{1,2}} \\[0.7em]
+g'(x_{2,1}).\frac{\partial L}{\partial z_{2,1}} &
+g'(x_{2,2}).\frac{\partial L}{\partial z_{2,2}} \\[0.7em]
+g'(x_{3,1}).\frac{\partial L}{\partial z_{3,1}} &
+g'(x_{3,2}).\frac{\partial L}{\partial z_{3,2}} \\[0.7em]
+\end{bmatrix}
+\nonumber \\
+&=
+\begin{bmatrix}
+g'(x_{1,1}) & g'(x_{1,2}) \\[0.5em]
+g'(x_{2,1}) & g'(x_{2,2}) \\[0.5em]
+g'(x_{3,1}) & g'(x_{3,2}) \\[0.5em]
+\end{bmatrix}
+\circ
+\begin{bmatrix}
+\frac{\partial L}{\partial z_{1,1}} & \frac{\partial L}{\partial z_{1,2}} \\[0.5em]
+\frac{\partial L}{\partial z_{2,1}} & \frac{\partial L}{\partial z_{2,2}} \\[0.5em]
+\frac{\partial L}{\partial z_{3,1}} & \frac{\partial L}{\partial z_{3,2}} \\[0.5em]
+\end{bmatrix}
+\nonumber \\
+&=
+g'(\matr{X}) \circ \frac{\partial L}{\partial \matr{Z}}
+\end{align}
+
+\section{Hadamard product}
+\subsection{Forward Pass}
+Let $\matr{X}$ be a $3 \times 2$ matrix, and let $\matr{Y}$ be a $3 \times 2$ matrix. Let $\matr{Z} = \matr{X} \circ \matr{Y}$ that is element-wise multiplication between $\matr{X}$ and $\matr{Y}$. $\matr{Z}$ will be of shape $3 \times 2$.
+
+\begin{displaymath}
+\matr{X} =
+\begin{bmatrix}
+x_{1,1} & x_{1,2} \\%[0.5em]
+x_{2,1} & x_{2,2} \\%[0.5em]
+x_{3,1} & x_{3,2} \\%[0.5em]
+\end{bmatrix}
+\end{displaymath}
+
+\begin{displaymath}
+\matr{Y} =
+\begin{bmatrix}
+y_{1,1} & y_{1,2} \\%[0.5em]
+y_{2,1} & y_{2,2} \\%[0.5em]
+y_{3,1} & y_{3,2} \\%[0.5em]
+\end{bmatrix}
+\end{displaymath}
+
+Given $\matr{Z} = \matr{X} \circ \matr{Y}$, Z is a $3 \times 2$ matrix which can be expressed as:
+
+\begin{align}
+\matr{Z} &= \begin{bmatrix}
+z_{1,1} & z_{1,2}\\[0.5em]
+z_{2,1} & z_{2,2}\\[0.5em]
+z_{3,1} & z_{3,2}\\[0.5em]
+\end{bmatrix}
+\\
+&=
+\begin{bmatrix}
+x_{1,1}.y_{1,1} & x_{1,2}.y_{1,2} \\[0.5em]
+x_{2,1}.y_{2,1} & x_{2,2}.y_{2,2} \\[0.5em]
+x_{3,1}.y_{3,1} & x_{3,2}.y_{3,2} \\[0.5em]
+\end{bmatrix}
+\end{align}
+
+\subsection{Backward Pass}
+We have $\frac{\partial L}{\partial \matr{Z}}$ of shape $3 \times 2$.
+
+\begin{displaymath}
+\frac{\partial L}{\partial \matr{Z}} =
+\begin{bmatrix}
+\frac{\partial L}{\partial z_{1,1}} & \frac{\partial L}{\partial z_{1,2}} \\[0.5em]
+\frac{\partial L}{\partial z_{2,1}} & \frac{\partial L}{\partial z_{2,2}} \\[0.5em]
+\frac{\partial L}{\partial z_{3,1}} & \frac{\partial L}{\partial z_{3,2}} \\[0.5em]
+\end{bmatrix}
+\end{displaymath}
+
+We now need to compute $\frac{\partial L}{\partial \matr{X}}$ and $\frac{\partial L}{\partial \matr{Y}}$. Using chain rule, we get:
+
+\begin{equation} \label{dX_hadamard_product}
+\frac{\partial L}{\partial \matr{X}} = \frac{\partial \matr{Z}}{\partial \matr{X}}\frac{\partial L}{\partial \matr{Z}}
+\end{equation}
+
+\begin{equation} \label{dY_hadamard_product}
+\frac{\partial L}{\partial \matr{Y}} = \frac{\partial \matr{Z}}{\partial \matr{Y}}\frac{\partial L}{\partial \matr{Z}}
+\end{equation}
+
+\subsubsection{Computing $\frac{\partial L}{\partial \matr{X}}$}
+To compute $\frac{\partial L}{\partial \matr{X}}$, we need to compute $\frac{\partial \matr{Z}}{\partial \matr{X}}$. To make it easy for us to think about and capture the Jacobian in a two dimensional matrix (as opposed to a tensor), we will reshape matrices $\matr{X}$, $\matr{Y}$ and $\matr{Z}$ as column vectors, and compute Jacobians on them. Once we have computed the column vector corresponding to $\frac{\partial L}{\partial \matr{X}}$, we will reshape it back to a matrix with the same shape as $\matr{X}$.
+
+\begin{align}
+\frac{\partial \matr{Z}}{\partial \matr{X}} &=
+\begin{bmatrix}
+\frac{\partial z_{1,1}}{\partial x_{1,1}} & \frac{\partial z_{1,2}}{\partial x_{1,1}} & \frac{\partial z_{2,1}}{\partial x_{1,1}} & \frac{\partial z_{2,2}}{\partial x_{1,1}} & \frac{\partial z_{3,1}}{\partial x_{1,1}} & \frac{\partial z_{3,2}}{\partial x_{1,1}}\\[0.7em]
+\frac{\partial z_{1,1}}{\partial x_{1,2}} & \frac{\partial z_{1,2}}{\partial x_{1,2}} & \frac{\partial z_{2,1}}{\partial x_{1,2}} & \frac{\partial z_{2,2}}{\partial x_{1,2}} & \frac{\partial z_{3,1}}{\partial x_{1,2}} & \frac{\partial z_{3,2}}{\partial x_{1,2}}\\[0.7em]
+\frac{\partial z_{1,1}}{\partial x_{2,1}} & \frac{\partial z_{1,2}}{\partial x_{2,1}} & \frac{\partial z_{2,1}}{\partial x_{2,1}} & \frac{\partial z_{2,2}}{\partial x_{2,1}} & \frac{\partial z_{3,1}}{\partial x_{2,1}} & \frac{\partial z_{3,2}}{\partial x_{2,1}}\\[0.7em]
+\frac{\partial z_{1,1}}{\partial x_{2,2}} & \frac{\partial z_{1,2}}{\partial x_{2,2}} & \frac{\partial z_{2,1}}{\partial x_{2,2}} & \frac{\partial z_{2,2}}{\partial x_{2,2}} & \frac{\partial z_{3,1}}{\partial x_{2,2}} & \frac{\partial z_{3,2}}{\partial x_{2,2}}\\[0.7em]
+\frac{\partial z_{1,1}}{\partial x_{3,1}} & \frac{\partial z_{1,2}}{\partial x_{3,1}} & \frac{\partial z_{2,1}}{\partial x_{3,1}} & \frac{\partial z_{2,2}}{\partial x_{3,1}} & \frac{\partial z_{3,1}}{\partial x_{3,1}} & \frac{\partial z_{3,2}}{\partial x_{3,1}}\\[0.7em]
+\frac{\partial z_{1,1}}{\partial x_{3,2}} & \frac{\partial z_{1,2}}{\partial x_{3,2}} & \frac{\partial z_{2,1}}{\partial x_{3,2}} & \frac{\partial z_{2,2}}{\partial x_{3,2}} & \frac{\partial z_{3,1}}{\partial x_{3,2}} & \frac{\partial z_{3,2}}{\partial x_{3,2}}\\[0.7em]
+\end{bmatrix} \nonumber
+\\ \label{dZbydX_hadamard_product}
+&=
+\begin{bmatrix}
+y_{1,1} & 0 & 0 & 0 & 0 & 0 \\[0.5em]
+0 & y_{1,2} & 0 & 0 & 0 & 0 \\[0.5em]
+0 & 0 & y_{2,1} & 0 & 0 & 0 \\[0.5em]
+0 & 0 & 0 & y_{2,2} & 0 & 0 \\[0.5em]
+0 & 0 & 0 & 0 & y_{3,1} & 0 \\[0.5em]
+0 & 0 & 0 & 0 & 0 & y_{3,2} \\[0.5em]
+\end{bmatrix}
+\end{align}
+
+Now, $\frac{\partial L}{\partial \matr{Z}}$ expressed as a column vector will be:
+
+\begin{equation} \label{dZAsColumnVector_hadamard_product_Y}
+\frac{\partial L}{\partial \matr{Z}} =
+\begin{bmatrix}
+\frac{\partial L}{\partial z_{1,1}} \\[0.7em]
+\frac{\partial L}{\partial z_{1,2}} \\[0.7em]
+\frac{\partial L}{\partial z_{2,1}} \\[0.7em]
+\frac{\partial L}{\partial z_{2,2}} \\[0.7em]
+\frac{\partial L}{\partial z_{3,1}} \\[0.7em]
+\frac{\partial L}{\partial z_{3,2}} \\[0.7em]
+\end{bmatrix}
+\end{equation}
+
+Plugging equations \ref{dZbydX_hadamard_product} and \ref{dZAsColumnVector_hadamard_product_Y} into equation \ref{dX_hadamard_product}, we get:
+
+\begin{align}
+\frac{\partial L}{\partial \matr{X}} &=
+\begin{bmatrix}
+y_{1,1} & 0 & 0 & 0 & 0 & 0 \\[0.5em]
+0 & y_{1,2} & 0 & 0 & 0 & 0 \\[0.5em]
+0 & 0 & y_{2,1} & 0 & 0 & 0 \\[0.5em]
+0 & 0 & 0 & y_{2,2} & 0 & 0 \\[0.5em]
+0 & 0 & 0 & 0 & y_{3,1} & 0 \\[0.5em]
+0 & 0 & 0 & 0 & 0 & y_{3,2} \\[0.5em]
+\end{bmatrix}
+\begin{bmatrix}
+\frac{\partial L}{\partial z_{1,1}} \\[0.7em]
+\frac{\partial L}{\partial z_{1,2}} \\[0.7em]
+\frac{\partial L}{\partial z_{2,1}} \\[0.7em]
+\frac{\partial L}{\partial z_{2,2}} \\[0.7em]
+\frac{\partial L}{\partial z_{3,1}} \\[0.7em]
+\frac{\partial L}{\partial z_{3,2}} \\[0.7em]
+\end{bmatrix}
+\nonumber \\
+&=
+\begin{bmatrix}
+y_{1,1}.\frac{\partial L}{\partial z_{1,1}} \\[0.7em]
+y_{1,2}.\frac{\partial L}{\partial z_{1,2}} \\[0.7em]
+y_{2,1}.\frac{\partial L}{\partial z_{2,1}} \\[0.7em]
+y_{2,2}.\frac{\partial L}{\partial z_{2,2}} \\[0.7em]
+y_{3,1}.\frac{\partial L}{\partial z_{3,1}} \\[0.7em]
+y_{3,2}.\frac{\partial L}{\partial z_{3,2}} \\[0.7em]
+\end{bmatrix} \label{dXAsColumnVector_hadamard_product}
+\end{align}
+
+Now, reshaping column vector in equation \ref{dXAsColumnVector_hadamard_product} as a matrix of shape $\matr{X}$, we get:
+
+\begin{align}
+\frac{\partial L}{\partial \matr{X}} &=
+\begin{bmatrix}
+y_{1,1}.\frac{\partial L}{\partial z_{1,1}} &
+y_{1,2}.\frac{\partial L}{\partial z_{1,2}} \\[0.7em]
+y_{2,1}.\frac{\partial L}{\partial z_{2,1}} &
+y_{2,2}.\frac{\partial L}{\partial z_{2,2}} \\[0.7em]
+y_{3,1}.\frac{\partial L}{\partial z_{3,1}} &
+y_{3,2}.\frac{\partial L}{\partial z_{3,2}} \\[0.7em]
+\end{bmatrix}
+\nonumber \\
+&=
+\begin{bmatrix}
+y_{1,1} & y_{1,2} \\%[0.5em]
+y_{2,1} & y_{2,2} \\%[0.5em]
+y_{3,1} & y_{3,2} \\%[0.5em]
+\end{bmatrix}
+\circ
+\begin{bmatrix}
+\frac{\partial L}{\partial z_{1,1}} & \frac{\partial L}{\partial z_{1,2}} \\[0.5em]
+\frac{\partial L}{\partial z_{2,1}} & \frac{\partial L}{\partial z_{2,2}} \\[0.5em]
+\frac{\partial L}{\partial z_{3,1}} & \frac{\partial L}{\partial z_{3,2}} \\[0.5em]
+\end{bmatrix}
+\nonumber \\
+&=
+\matr{Y} \circ \frac{\partial L}{\partial \matr{Z}}
+\end{align}
+
+\subsubsection{Computing $\frac{\partial L}{\partial \matr{Y}}$}
+To compute $\frac{\partial L}{\partial \matr{Y}}$, we need to compute $\frac{\partial \matr{Z}}{\partial \matr{Y}}$. To make it easy for us to think about and capture the Jacobian in a two dimensional matrix (as opposed to a tensor), we will reshape matrices $\matr{X}$, $\matr{Y}$ and $\matr{Z}$ as column vectors, and compute Jacobians on them. Once we have computed the column vector corresponding to $\frac{\partial L}{\partial \matr{Y}}$, we will reshape it back to a matrix with the same shape as $\matr{Y}$.
+
+\begin{align}
+\frac{\partial \matr{Z}}{\partial \matr{X}} &=
+\begin{bmatrix}
+\frac{\partial z_{1,1}}{\partial y_{1,1}} & \frac{\partial z_{1,2}}{\partial y_{1,1}} & \frac{\partial z_{2,1}}{\partial y_{1,1}} & \frac{\partial z_{2,2}}{\partial y_{1,1}} & \frac{\partial z_{3,1}}{\partial y_{1,1}} & \frac{\partial z_{3,2}}{\partial y_{1,1}}\\[0.7em]
+\frac{\partial z_{1,1}}{\partial y_{1,2}} & \frac{\partial z_{1,2}}{\partial y_{1,2}} & \frac{\partial z_{2,1}}{\partial y_{1,2}} & \frac{\partial z_{2,2}}{\partial y_{1,2}} & \frac{\partial z_{3,1}}{\partial y_{1,2}} & \frac{\partial z_{3,2}}{\partial y_{1,2}}\\[0.7em]
+\frac{\partial z_{1,1}}{\partial y_{2,1}} & \frac{\partial z_{1,2}}{\partial y_{2,1}} & \frac{\partial z_{2,1}}{\partial y_{2,1}} & \frac{\partial z_{2,2}}{\partial y_{2,1}} & \frac{\partial z_{3,1}}{\partial y_{2,1}} & \frac{\partial z_{3,2}}{\partial y_{2,1}}\\[0.7em]
+\frac{\partial z_{1,1}}{\partial y_{2,2}} & \frac{\partial z_{1,2}}{\partial y_{2,2}} & \frac{\partial z_{2,1}}{\partial y_{2,2}} & \frac{\partial z_{2,2}}{\partial y_{2,2}} & \frac{\partial z_{3,1}}{\partial y_{2,2}} & \frac{\partial z_{3,2}}{\partial y_{2,2}}\\[0.7em]
+\frac{\partial z_{1,1}}{\partial y_{3,1}} & \frac{\partial z_{1,2}}{\partial y_{3,1}} & \frac{\partial z_{2,1}}{\partial y_{3,1}} & \frac{\partial z_{2,2}}{\partial y_{3,1}} & \frac{\partial z_{3,1}}{\partial y_{3,1}} & \frac{\partial z_{3,2}}{\partial y_{3,1}}\\[0.7em]
+\frac{\partial z_{1,1}}{\partial y_{3,2}} & \frac{\partial z_{1,2}}{\partial y_{3,2}} & \frac{\partial z_{2,1}}{\partial y_{3,2}} & \frac{\partial z_{2,2}}{\partial y_{3,2}} & \frac{\partial z_{3,1}}{\partial y_{3,2}} & \frac{\partial z_{3,2}}{\partial y_{3,2}}\\[0.7em]
+\end{bmatrix} \nonumber
+\\ \label{dZbydY_hadamard_product}
+&=
+\begin{bmatrix}
+x_{1,1} & 0 & 0 & 0 & 0 & 0 \\[0.5em]
+0 & x_{1,2} & 0 & 0 & 0 & 0 \\[0.5em]
+0 & 0 & x_{2,1} & 0 & 0 & 0 \\[0.5em]
+0 & 0 & 0 & x_{2,2} & 0 & 0 \\[0.5em]
+0 & 0 & 0 & 0 & x_{3,1} & 0 \\[0.5em]
+0 & 0 & 0 & 0 & 0 & x_{3,2} \\[0.5em]
+\end{bmatrix}
+\end{align}
+
+Now, $\frac{\partial L}{\partial \matr{Z}}$ expressed as a column vector will be:
+
+\begin{equation} \label{dZAsColumnVector_hadamard_product_X}
+\frac{\partial L}{\partial \matr{Z}} =
+\begin{bmatrix}
+\frac{\partial L}{\partial z_{1,1}} \\[0.7em]
+\frac{\partial L}{\partial z_{1,2}} \\[0.7em]
+\frac{\partial L}{\partial z_{2,1}} \\[0.7em]
+\frac{\partial L}{\partial z_{2,2}} \\[0.7em]
+\frac{\partial L}{\partial z_{3,1}} \\[0.7em]
+\frac{\partial L}{\partial z_{3,2}} \\[0.7em]
+\end{bmatrix}
+\end{equation}
+
+Plugging equations \ref{dZbydY_hadamard_product} and \ref{dZAsColumnVector_hadamard_product_X} into equation \ref{dY_hadamard_product}, we get:
+
+\begin{align}
+\frac{\partial L}{\partial \matr{X}} &=
+\begin{bmatrix}
+x_{1,1} & 0 & 0 & 0 & 0 & 0 \\[0.5em]
+0 & x_{1,2} & 0 & 0 & 0 & 0 \\[0.5em]
+0 & 0 & x_{2,1} & 0 & 0 & 0 \\[0.5em]
+0 & 0 & 0 & x_{2,2} & 0 & 0 \\[0.5em]
+0 & 0 & 0 & 0 & x_{3,1} & 0 \\[0.5em]
+0 & 0 & 0 & 0 & 0 & x_{3,2} \\[0.5em]
+\end{bmatrix}
+\begin{bmatrix}
+\frac{\partial L}{\partial z_{1,1}} \\[0.7em]
+\frac{\partial L}{\partial z_{1,2}} \\[0.7em]
+\frac{\partial L}{\partial z_{2,1}} \\[0.7em]
+\frac{\partial L}{\partial z_{2,2}} \\[0.7em]
+\frac{\partial L}{\partial z_{3,1}} \\[0.7em]
+\frac{\partial L}{\partial z_{3,2}} \\[0.7em]
+\end{bmatrix}
+\nonumber \\
+&=
+\begin{bmatrix}
+x_{1,1}.\frac{\partial L}{\partial z_{1,1}} \\[0.7em]
+x_{1,2}.\frac{\partial L}{\partial z_{1,2}} \\[0.7em]
+x_{2,1}.\frac{\partial L}{\partial z_{2,1}} \\[0.7em]
+x_{2,2}.\frac{\partial L}{\partial z_{2,2}} \\[0.7em]
+x_{3,1}.\frac{\partial L}{\partial z_{3,1}} \\[0.7em]
+x_{3,2}.\frac{\partial L}{\partial z_{3,2}} \\[0.7em]
+\end{bmatrix} \label{dYAsColumnVector_hadamard_product}
+\end{align}
+
+Now, reshaping column vector in equation \ref{dYAsColumnVector_hadamard_product} as a matrix of shape $\matr{Y}$, we get:
+
+\begin{align}
+\frac{\partial L}{\partial \matr{X}} &=
+\begin{bmatrix}
+x_{1,1}.\frac{\partial L}{\partial z_{1,1}} &
+x_{1,2}.\frac{\partial L}{\partial z_{1,2}} \\[0.7em]
+x_{2,1}.\frac{\partial L}{\partial z_{2,1}} &
+x_{2,2}.\frac{\partial L}{\partial z_{2,2}} \\[0.7em]
+x_{3,1}.\frac{\partial L}{\partial z_{3,1}} &
+x_{3,2}.\frac{\partial L}{\partial z_{3,2}} \\[0.7em]
+\end{bmatrix}
+\nonumber \\
+&=
+\begin{bmatrix}
+x_{1,1} & x_{1,2} \\%[0.5em]
+x_{2,1} & x_{2,2} \\%[0.5em]
+x_{3,1} & x_{3,2} \\%[0.5em]
+\end{bmatrix}
+\circ
+\begin{bmatrix}
+\frac{\partial L}{\partial z_{1,1}} & \frac{\partial L}{\partial z_{1,2}} \\[0.5em]
+\frac{\partial L}{\partial z_{2,1}} & \frac{\partial L}{\partial z_{2,2}} \\[0.5em]
+\frac{\partial L}{\partial z_{3,1}} & \frac{\partial L}{\partial z_{3,2}} \\[0.5em]
+\end{bmatrix}
+\nonumber \\
+&=
+\matr{X} \circ \frac{\partial L}{\partial \matr{Z}}
+\end{align}
+
+\section{Matrix Addition}
+\subsection{Forward Pass}
+Let $\matr{X}$ be a $3 \times 2$ matrix, and let $\matr{Y}$ be a $3 \times 2$ matrix. Let $\matr{Z} = \matr{X} + \matr{Y}$ that is element-wise addition between $\matr{X}$ and $\matr{Y}$. $\matr{Z}$ will be of shape $3 \times 2$.
+
+\begin{displaymath}
+\matr{X} =
+\begin{bmatrix}
+x_{1,1} & x_{1,2} \\%[0.5em]
+x_{2,1} & x_{2,2} \\%[0.5em]
+x_{3,1} & x_{3,2} \\%[0.5em]
+\end{bmatrix}
+\end{displaymath}
+
+\begin{displaymath}
+\matr{Y} =
+\begin{bmatrix}
+y_{1,1} & y_{1,2} \\%[0.5em]
+y_{2,1} & y_{2,2} \\%[0.5em]
+y_{3,1} & y_{3,2} \\%[0.5em]
+\end{bmatrix}
+\end{displaymath}
+
+Given $\matr{Z} = \matr{X} + \matr{Y}$, Z is a $3 \times 2$ matrix which can be expressed as:
+
+\begin{align}
+\matr{Z} &= \begin{bmatrix}
+z_{1,1} & z_{1,2}\\[0.5em]
+z_{2,1} & z_{2,2}\\[0.5em]
+z_{3,1} & z_{3,2}\\[0.5em]
+\end{bmatrix}
+\\
+&=
+\begin{bmatrix}
+x_{1,1} + y_{1,1} & x_{1,2} + y_{1,2} \\[0.5em]
+x_{2,1} + y_{2,1} & x_{2,2} + y_{2,2} \\[0.5em]
+x_{3,1} + y_{3,1} & x_{3,2} + y_{3,2} \\[0.5em]
+\end{bmatrix}
+\end{align}
+
+\subsection{Backward Pass}
+We have $\frac{\partial L}{\partial \matr{Z}}$ of shape $3 \times 2$.
+
+\begin{displaymath}
+\frac{\partial L}{\partial \matr{Z}} =
+\begin{bmatrix}
+\frac{\partial L}{\partial z_{1,1}} & \frac{\partial L}{\partial z_{1,2}} \\[0.5em]
+\frac{\partial L}{\partial z_{2,1}} & \frac{\partial L}{\partial z_{2,2}} \\[0.5em]
+\frac{\partial L}{\partial z_{3,1}} & \frac{\partial L}{\partial z_{3,2}} \\[0.5em]
+\end{bmatrix}
+\end{displaymath}
+
+We now need to compute $\frac{\partial L}{\partial \matr{X}}$ and $\frac{\partial L}{\partial \matr{Y}}$. Using chain rule, we get:
+
+\begin{equation} \label{dX_matrix_addition}
+\frac{\partial L}{\partial \matr{X}} = \frac{\partial \matr{Z}}{\partial \matr{X}}\frac{\partial L}{\partial \matr{Z}}
+\end{equation}
+
+\begin{equation} \label{dY_matrix_addition}
+\frac{\partial L}{\partial \matr{Y}} = \frac{\partial \matr{Z}}{\partial \matr{Y}}\frac{\partial L}{\partial \matr{Z}}
+\end{equation}
+
+\subsubsection{Computing $\frac{\partial L}{\partial \matr{X}}$}
+To compute $\frac{\partial L}{\partial \matr{X}}$, we need to compute $\frac{\partial \matr{Z}}{\partial \matr{X}}$. To make it easy for us to think about and capture the Jacobian in a two dimensional matrix (as opposed to a tensor), we will reshape matrices $\matr{X}$, $\matr{Y}$ and $\matr{Z}$ as column vectors, and compute Jacobians on them. Once we have computed the column vector corresponding to $\frac{\partial L}{\partial \matr{X}}$, we will reshape it back to a matrix with the same shape as $\matr{X}$.
+
+\begin{align}
+\frac{\partial \matr{Z}}{\partial \matr{X}} &=
+\begin{bmatrix}
+\frac{\partial z_{1,1}}{\partial x_{1,1}} & \frac{\partial z_{1,2}}{\partial x_{1,1}} & \frac{\partial z_{2,1}}{\partial x_{1,1}} & \frac{\partial z_{2,2}}{\partial x_{1,1}} & \frac{\partial z_{3,1}}{\partial x_{1,1}} & \frac{\partial z_{3,2}}{\partial x_{1,1}}\\[0.7em]
+\frac{\partial z_{1,1}}{\partial x_{1,2}} & \frac{\partial z_{1,2}}{\partial x_{1,2}} & \frac{\partial z_{2,1}}{\partial x_{1,2}} & \frac{\partial z_{2,2}}{\partial x_{1,2}} & \frac{\partial z_{3,1}}{\partial x_{1,2}} & \frac{\partial z_{3,2}}{\partial x_{1,2}}\\[0.7em]
+\frac{\partial z_{1,1}}{\partial x_{2,1}} & \frac{\partial z_{1,2}}{\partial x_{2,1}} & \frac{\partial z_{2,1}}{\partial x_{2,1}} & \frac{\partial z_{2,2}}{\partial x_{2,1}} & \frac{\partial z_{3,1}}{\partial x_{2,1}} & \frac{\partial z_{3,2}}{\partial x_{2,1}}\\[0.7em]
+\frac{\partial z_{1,1}}{\partial x_{2,2}} & \frac{\partial z_{1,2}}{\partial x_{2,2}} & \frac{\partial z_{2,1}}{\partial x_{2,2}} & \frac{\partial z_{2,2}}{\partial x_{2,2}} & \frac{\partial z_{3,1}}{\partial x_{2,2}} & \frac{\partial z_{3,2}}{\partial x_{2,2}}\\[0.7em]
+\frac{\partial z_{1,1}}{\partial x_{3,1}} & \frac{\partial z_{1,2}}{\partial x_{3,1}} & \frac{\partial z_{2,1}}{\partial x_{3,1}} & \frac{\partial z_{2,2}}{\partial x_{3,1}} & \frac{\partial z_{3,1}}{\partial x_{3,1}} & \frac{\partial z_{3,2}}{\partial x_{3,1}}\\[0.7em]
+\frac{\partial z_{1,1}}{\partial x_{3,2}} & \frac{\partial z_{1,2}}{\partial x_{3,2}} & \frac{\partial z_{2,1}}{\partial x_{3,2}} & \frac{\partial z_{2,2}}{\partial x_{3,2}} & \frac{\partial z_{3,1}}{\partial x_{3,2}} & \frac{\partial z_{3,2}}{\partial x_{3,2}}\\[0.7em]
+\end{bmatrix} \nonumber
+\\ \label{dZbydX_matrix_addition}
+&=
+\begin{bmatrix}
+1 & 0 & 0 & 0 & 0 & 0 \\%[0.5em]
+0 & 1 & 0 & 0 & 0 & 0 \\%[0.5em]
+0 & 0 & 1 & 0 & 0 & 0 \\%[0.5em]
+0 & 0 & 0 & 1 & 0 & 0 \\%[0.5em]
+0 & 0 & 0 & 0 & 1 & 0 \\%[0.5em]
+0 & 0 & 0 & 0 & 0 & 1 \\%[0.5em]
+\end{bmatrix}
+\end{align}
+
+Now, $\frac{\partial L}{\partial \matr{Z}}$ expressed as a column vector will be:
+
+\begin{equation} \label{dZAsColumnVector_matrix_addition_X}
+\frac{\partial L}{\partial \matr{Z}} =
+\begin{bmatrix}
+\frac{\partial L}{\partial z_{1,1}} \\[0.7em]
+\frac{\partial L}{\partial z_{1,2}} \\[0.7em]
+\frac{\partial L}{\partial z_{2,1}} \\[0.7em]
+\frac{\partial L}{\partial z_{2,2}} \\[0.7em]
+\frac{\partial L}{\partial z_{3,1}} \\[0.7em]
+\frac{\partial L}{\partial z_{3,2}} \\[0.7em]
+\end{bmatrix}
+\end{equation}
+
+Plugging equations \ref{dZbydX_matrix_addition} and \ref{dZAsColumnVector_matrix_addition_X} into equation \ref{dX_matrix_addition}, we get:
+
+\begin{align}
+\frac{\partial L}{\partial \matr{X}} &=
+\begin{bmatrix}
+1 & 0 & 0 & 0 & 0 & 0 \\%[0.5em]
+0 & 1 & 0 & 0 & 0 & 0 \\%[0.5em]
+0 & 0 & 1 & 0 & 0 & 0 \\%[0.5em]
+0 & 0 & 0 & 1 & 0 & 0 \\%[0.5em]
+0 & 0 & 0 & 0 & 1 & 0 \\%[0.5em]
+0 & 0 & 0 & 0 & 0 & 1 \\%[0.5em]
+\end{bmatrix}
+\begin{bmatrix}
+\frac{\partial L}{\partial z_{1,1}} \\[0.7em]
+\frac{\partial L}{\partial z_{1,2}} \\[0.7em]
+\frac{\partial L}{\partial z_{2,1}} \\[0.7em]
+\frac{\partial L}{\partial z_{2,2}} \\[0.7em]
+\frac{\partial L}{\partial z_{3,1}} \\[0.7em]
+\frac{\partial L}{\partial z_{3,2}} \\[0.7em]
+\end{bmatrix}
+\nonumber \\
+&=
+\begin{bmatrix}
+\frac{\partial L}{\partial z_{1,1}} \\[0.7em]
+\frac{\partial L}{\partial z_{1,2}} \\[0.7em]
+\frac{\partial L}{\partial z_{2,1}} \\[0.7em]
+\frac{\partial L}{\partial z_{2,2}} \\[0.7em]
+\frac{\partial L}{\partial z_{3,1}} \\[0.7em]
+\frac{\partial L}{\partial z_{3,2}} \\[0.7em]
+\end{bmatrix} \label{dXAsColumnVector_matrix_addition}
+\end{align}
+
+Now, reshaping column vector in equation \ref{dXAsColumnVector_matrix_addition} as a matrix of shape $\matr{X}$, we get:
+
+\begin{align}
+\frac{\partial L}{\partial \matr{X}} &=
+\begin{bmatrix}
+\frac{\partial L}{\partial z_{1,1}} &
+\frac{\partial L}{\partial z_{1,2}} \\[0.7em]
+\frac{\partial L}{\partial z_{2,1}} &
+\frac{\partial L}{\partial z_{2,2}} \\[0.7em]
+\frac{\partial L}{\partial z_{3,1}} &
+\frac{\partial L}{\partial z_{3,2}} \\[0.7em]
+\end{bmatrix}
+\nonumber \\
+&=
+\begin{bmatrix}
+\frac{\partial L}{\partial z_{1,1}} & \frac{\partial L}{\partial z_{1,2}} \\[0.5em]
+\frac{\partial L}{\partial z_{2,1}} & \frac{\partial L}{\partial z_{2,2}} \\[0.5em]
+\frac{\partial L}{\partial z_{3,1}} & \frac{\partial L}{\partial z_{3,2}} \\[0.5em]
+\end{bmatrix}
+\nonumber \\
+&=
+\frac{\partial L}{\partial \matr{Z}}
+\end{align}
+
+\subsubsection{Computing $\frac{\partial L}{\partial \matr{Y}}$}
+To compute $\frac{\partial L}{\partial \matr{Y}}$, we need to compute $\frac{\partial \matr{Z}}{\partial \matr{Y}}$. To make it easy for us to think about and capture the Jacobian in a two dimensional matrix (as opposed to a tensor), we will reshape matrices $\matr{X}$, $\matr{Y}$ and $\matr{Z}$ as column vectors, and compute Jacobians on them. Once we have computed the column vector corresponding to $\frac{\partial L}{\partial \matr{Y}}$, we will reshape it back to a matrix with the same shape as $\matr{Y}$.
+
+\begin{align}
+\frac{\partial \matr{Z}}{\partial \matr{X}} &=
+\begin{bmatrix}
+\frac{\partial z_{1,1}}{\partial y_{1,1}} & \frac{\partial z_{1,2}}{\partial y_{1,1}} & \frac{\partial z_{2,1}}{\partial y_{1,1}} & \frac{\partial z_{2,2}}{\partial y_{1,1}} & \frac{\partial z_{3,1}}{\partial y_{1,1}} & \frac{\partial z_{3,2}}{\partial y_{1,1}}\\[0.7em]
+\frac{\partial z_{1,1}}{\partial y_{1,2}} & \frac{\partial z_{1,2}}{\partial y_{1,2}} & \frac{\partial z_{2,1}}{\partial y_{1,2}} & \frac{\partial z_{2,2}}{\partial y_{1,2}} & \frac{\partial z_{3,1}}{\partial y_{1,2}} & \frac{\partial z_{3,2}}{\partial y_{1,2}}\\[0.7em]
+\frac{\partial z_{1,1}}{\partial y_{2,1}} & \frac{\partial z_{1,2}}{\partial y_{2,1}} & \frac{\partial z_{2,1}}{\partial y_{2,1}} & \frac{\partial z_{2,2}}{\partial y_{2,1}} & \frac{\partial z_{3,1}}{\partial y_{2,1}} & \frac{\partial z_{3,2}}{\partial y_{2,1}}\\[0.7em]
+\frac{\partial z_{1,1}}{\partial y_{2,2}} & \frac{\partial z_{1,2}}{\partial y_{2,2}} & \frac{\partial z_{2,1}}{\partial y_{2,2}} & \frac{\partial z_{2,2}}{\partial y_{2,2}} & \frac{\partial z_{3,1}}{\partial y_{2,2}} & \frac{\partial z_{3,2}}{\partial y_{2,2}}\\[0.7em]
+\frac{\partial z_{1,1}}{\partial y_{3,1}} & \frac{\partial z_{1,2}}{\partial y_{3,1}} & \frac{\partial z_{2,1}}{\partial y_{3,1}} & \frac{\partial z_{2,2}}{\partial y_{3,1}} & \frac{\partial z_{3,1}}{\partial y_{3,1}} & \frac{\partial z_{3,2}}{\partial y_{3,1}}\\[0.7em]
+\frac{\partial z_{1,1}}{\partial y_{3,2}} & \frac{\partial z_{1,2}}{\partial y_{3,2}} & \frac{\partial z_{2,1}}{\partial y_{3,2}} & \frac{\partial z_{2,2}}{\partial y_{3,2}} & \frac{\partial z_{3,1}}{\partial y_{3,2}} & \frac{\partial z_{3,2}}{\partial y_{3,2}}\\[0.7em]
+\end{bmatrix} \nonumber
+\\ \label{dZbydY_matrix_addition}
+&=
+\begin{bmatrix}
+1 & 0 & 0 & 0 & 0 & 0 \\%[0.5em]
+0 & 1 & 0 & 0 & 0 & 0 \\%[0.5em]
+0 & 0 & 1 & 0 & 0 & 0 \\%[0.5em]
+0 & 0 & 0 & 1 & 0 & 0 \\%[0.5em]
+0 & 0 & 0 & 0 & 1 & 0 \\%[0.5em]
+0 & 0 & 0 & 0 & 0 & 1 \\%[0.5em]
+\end{bmatrix}
+\end{align}
+
+Now, $\frac{\partial L}{\partial \matr{Z}}$ expressed as a column vector will be:
+
+\begin{equation} \label{dZAsColumnVector_matrix_addition_Y}
+\frac{\partial L}{\partial \matr{Z}} =
+\begin{bmatrix}
+\frac{\partial L}{\partial z_{1,1}} \\[0.7em]
+\frac{\partial L}{\partial z_{1,2}} \\[0.7em]
+\frac{\partial L}{\partial z_{2,1}} \\[0.7em]
+\frac{\partial L}{\partial z_{2,2}} \\[0.7em]
+\frac{\partial L}{\partial z_{3,1}} \\[0.7em]
+\frac{\partial L}{\partial z_{3,2}} \\[0.7em]
+\end{bmatrix}
+\end{equation}
+
+Plugging equations \ref{dZbydX_matrix_addition} and \ref{dZAsColumnVector_matrix_addition_Y} into equation \ref{dY_matrix_addition}, we get:
+
+\begin{align}
+\frac{\partial L}{\partial \matr{X}} &=
+\begin{bmatrix}
+1 & 0 & 0 & 0 & 0 & 0 \\%[0.5em]
+0 & 1 & 0 & 0 & 0 & 0 \\%[0.5em]
+0 & 0 & 1 & 0 & 0 & 0 \\%[0.5em]
+0 & 0 & 0 & 1 & 0 & 0 \\%[0.5em]
+0 & 0 & 0 & 0 & 1 & 0 \\%[0.5em]
+0 & 0 & 0 & 0 & 0 & 1 \\%[0.5em]
+\end{bmatrix}
+\begin{bmatrix}
+\frac{\partial L}{\partial z_{1,1}} \\[0.7em]
+\frac{\partial L}{\partial z_{1,2}} \\[0.7em]
+\frac{\partial L}{\partial z_{2,1}} \\[0.7em]
+\frac{\partial L}{\partial z_{2,2}} \\[0.7em]
+\frac{\partial L}{\partial z_{3,1}} \\[0.7em]
+\frac{\partial L}{\partial z_{3,2}} \\[0.7em]
+\end{bmatrix}
+\nonumber \\
+&=
+\begin{bmatrix}
+\frac{\partial L}{\partial z_{1,1}} \\[0.7em]
+\frac{\partial L}{\partial z_{1,2}} \\[0.7em]
+\frac{\partial L}{\partial z_{2,1}} \\[0.7em]
+\frac{\partial L}{\partial z_{2,2}} \\[0.7em]
+\frac{\partial L}{\partial z_{3,1}} \\[0.7em]
+\frac{\partial L}{\partial z_{3,2}} \\[0.7em]
+\end{bmatrix} \label{dYAsColumnVector_matrix_addition}
+\end{align}
+
+Now, reshaping column vector in equation \ref{dYAsColumnVector_matrix_addition} as a matrix of shape $\matr{Y}$, we get:
+
+\begin{align}
+\frac{\partial L}{\partial \matr{Y}} &=
+\begin{bmatrix}
+\frac{\partial L}{\partial z_{1,1}} &
+\frac{\partial L}{\partial z_{1,2}} \\[0.7em]
+\frac{\partial L}{\partial z_{2,1}} &
+\frac{\partial L}{\partial z_{2,2}} \\[0.7em]
+\frac{\partial L}{\partial z_{3,1}} &
+\frac{\partial L}{\partial z_{3,2}} \\[0.7em]
+\end{bmatrix}
+\nonumber \\
+&=
+\begin{bmatrix}
+\frac{\partial L}{\partial z_{1,1}} & \frac{\partial L}{\partial z_{1,2}} \\[0.5em]
+\frac{\partial L}{\partial z_{2,1}} & \frac{\partial L}{\partial z_{2,2}} \\[0.5em]
+\frac{\partial L}{\partial z_{3,1}} & \frac{\partial L}{\partial z_{3,2}} \\[0.5em]
+\end{bmatrix}
+\nonumber \\
+&=
+\frac{\partial L}{\partial \matr{Z}}
+\end{align}
+
+\section{Transpose}
+\subsection{Forward Pass}
+Suppose we are given a matrix $\matr{X}$ of shape $3 \times 2$. Let $\matr{Z} = \transpose{\matr{X}}$. $\matr{Z}$ will be of shape $2 \times 3$.
+
+\begin{displaymath}
+\matr{X} =
+\begin{bmatrix}
+x_{1,1} & x_{1,2} \\%[0.5em]
+x_{2,1} & x_{2,2} \\%[0.5em]
+x_{3,1} & x_{3,2} \\%[0.5em]
+\end{bmatrix}
+\end{displaymath}
+
+$\matr{Z}$ can be expressed as:
+
+\begin{align}
+\matr{Z} &=
+\begin{bmatrix}
+z_{1,1} & z_{1,2} & z_{1,3}\\%[0.5em]
+z_{2,1} & z_{2,2} & z_{2,3}\\%[0.5em]
+\end{bmatrix}
+\nonumber \\
+&=
+\begin{bmatrix}
+x_{1,1} & x_{2,1} & x_{3,1} \\%[0.5em]
+x_{1,2} & x_{2,2} & x_{3,2} \\%[0.5em]
+\end{bmatrix}
+\end{align}
+
+\subsection{Backward Pass}
+We have $\frac{\partial L}{\partial \matr{Z}}$ of shape $2 \times 3$.
+
+\begin{displaymath}
+\frac{\partial L}{\partial \matr{Z}} =
+\begin{bmatrix}
+\frac{\partial L}{\partial z_{1,1}} & \frac{\partial L}{\partial z_{1,2}} & \frac{\partial L}{\partial z_{1,3}} \\[0.5em]
+\frac{\partial L}{\partial z_{2,1}} & \frac{\partial L}{\partial z_{2,2}} & \frac{\partial L}{\partial z_{2,3}} \\[0.5em]
+\end{bmatrix}
+\end{displaymath}
+
+We now need to compute $\frac{\partial L}{\partial \matr{X}}$. Using chain rule, we get:
+
+\begin{equation} \label{dX_transpose}
+\frac{\partial L}{\partial \matr{X}} = \frac{\partial \matr{Z}}{\partial \matr{X}}\frac{\partial L}{\partial \matr{Z}}
+\end{equation}
+
+\subsubsection{Computing $\frac{\partial L}{\partial \matr{X}}$}
+To compute $\frac{\partial L}{\partial \matr{X}}$, we need to compute $\frac{\partial \matr{Z}}{\partial \matr{X}}$. To make it easy for us to think about and capture the Jacobian in a two dimensional matrix (as opposed to a tensor), we will reshape matrices $\matr{X}$ and $\matr{Z}$ as column vectors, and compute Jacobians on them. Once we have computed the column vector corresponding to $\frac{\partial L}{\partial \matr{X}}$, we will reshape it back to a matrix with the same shape as $\matr{X}$.
+
+\begin{align}
+\frac{\partial \matr{Z}}{\partial \matr{X}} &=
+\begin{bmatrix}
+\frac{\partial z_{1,1}}{\partial x_{1,1}} & \frac{\partial z_{1,2}}{\partial x_{1,1}} & \frac{\partial z_{1,3}}{\partial x_{1,1}} & \frac{\partial z_{2,1}}{\partial x_{1,1}} & \frac{\partial z_{2,2}}{\partial x_{1,1}} & \frac{\partial z_{3,3}}{\partial x_{1,1}}\\[0.7em]
+\frac{\partial z_{1,1}}{\partial x_{1,2}} & \frac{\partial z_{1,2}}{\partial x_{1,2}} & \frac{\partial z_{1,3}}{\partial x_{1,2}} & \frac{\partial z_{2,1}}{\partial x_{1,2}} & \frac{\partial z_{2,2}}{\partial x_{1,2}} & \frac{\partial z_{3,3}}{\partial x_{1,2}}\\[0.7em]
+\frac{\partial z_{1,1}}{\partial x_{2,1}} & \frac{\partial z_{1,2}}{\partial x_{2,1}} & \frac{\partial z_{1,3}}{\partial x_{2,1}} & \frac{\partial z_{2,1}}{\partial x_{2,1}} & \frac{\partial z_{2,2}}{\partial x_{2,1}} & \frac{\partial z_{3,3}}{\partial x_{2,1}}\\[0.7em]
+\frac{\partial z_{1,1}}{\partial x_{2,2}} & \frac{\partial z_{1,2}}{\partial x_{2,2}} & \frac{\partial z_{1,3}}{\partial x_{2,2}} & \frac{\partial z_{2,1}}{\partial x_{2,2}} & \frac{\partial z_{2,2}}{\partial x_{2,2}} & \frac{\partial z_{3,3}}{\partial x_{2,2}}\\[0.7em]
+\frac{\partial z_{1,1}}{\partial x_{3,1}} & \frac{\partial z_{1,2}}{\partial x_{3,1}} & \frac{\partial z_{1,3}}{\partial x_{3,1}} & \frac{\partial z_{2,1}}{\partial x_{3,1}} & \frac{\partial z_{2,2}}{\partial x_{3,1}} & \frac{\partial z_{3,3}}{\partial x_{3,1}}\\[0.7em]
+\frac{\partial z_{1,1}}{\partial x_{3,2}} & \frac{\partial z_{1,2}}{\partial x_{3,2}} & \frac{\partial z_{1,3}}{\partial x_{3,2}} & \frac{\partial z_{2,1}}{\partial x_{3,2}} & \frac{\partial z_{2,2}}{\partial x_{3,2}} & \frac{\partial z_{3,3}}{\partial x_{3,2}}\\[0.7em]
+\end{bmatrix} \nonumber
+\\ \label{dZbydX_transpose}
+&=
+\begin{bmatrix}
+1 & 0 & 0 & 0 & 0 & 0 \\%[0.5em]
+0 & 0 & 0 & 1 & 0 & 0 \\%[0.5em]
+0 & 1 & 0 & 0 & 0 & 0 \\%[0.5em]
+0 & 0 & 0 & 0 & 1 & 0 \\%[0.5em]
+0 & 0 & 1 & 0 & 0 & 0 \\%[0.5em]
+0 & 0 & 0 & 0 & 0 & 1 \\%[0.5em]
+\end{bmatrix}
+\end{align}
+
+Now, $\frac{\partial L}{\partial \matr{Z}}$ expressed as a column vector will be:
+
+\begin{equation} \label{dZAsColumnVector_transpose}
+\frac{\partial L}{\partial \matr{Z}} =
+\begin{bmatrix}
+\frac{\partial L}{\partial z_{1,1}} \\[0.7em]
+\frac{\partial L}{\partial z_{1,2}} \\[0.7em]
+\frac{\partial L}{\partial z_{1,3}} \\[0.7em]
+\frac{\partial L}{\partial z_{2,1}} \\[0.7em]
+\frac{\partial L}{\partial z_{2,2}} \\[0.7em]
+\frac{\partial L}{\partial z_{2,3}} \\[0.7em]
+\end{bmatrix}
+\end{equation}
+
+
+Plugging equations \ref{dZbydX_transpose} and \ref{dZAsColumnVector_transpose} into equation \ref{dX_transpose}, we get:
+
+\begin{align}
+\frac{\partial L}{\partial \matr{X}} &=
+\begin{bmatrix}
+1 & 0 & 0 & 0 & 0 & 0 \\%[0.5em]
+0 & 0 & 0 & 1 & 0 & 0 \\%[0.5em]
+0 & 1 & 0 & 0 & 0 & 0 \\%[0.5em]
+0 & 0 & 0 & 0 & 1 & 0 \\%[0.5em]
+0 & 0 & 1 & 0 & 0 & 0 \\%[0.5em]
+0 & 0 & 0 & 0 & 0 & 1 \\%[0.5em]
+\end{bmatrix}
+\begin{bmatrix}
+\frac{\partial L}{\partial z_{1,1}} \\[0.7em]
+\frac{\partial L}{\partial z_{1,2}} \\[0.7em]
+\frac{\partial L}{\partial z_{1,3}} \\[0.7em]
+\frac{\partial L}{\partial z_{2,1}} \\[0.7em]
+\frac{\partial L}{\partial z_{2,2}} \\[0.7em]
+\frac{\partial L}{\partial z_{2,3}} \\[0.7em]
+\end{bmatrix}
+\nonumber \\
+&=
+\begin{bmatrix}
+\frac{\partial L}{\partial z_{1,1}} \\[0.7em]
+\frac{\partial L}{\partial z_{2,1}} \\[0.7em]
+\frac{\partial L}{\partial z_{1,2}} \\[0.7em]
+\frac{\partial L}{\partial z_{2,2}} \\[0.7em]
+\frac{\partial L}{\partial z_{1,3}} \\[0.7em]
+\frac{\partial L}{\partial z_{2,3}} \\[0.7em]
+\end{bmatrix} \label{dXAsColumnVector_transpose}
+\end{align}
+
+Now, reshaping column vector in equation \ref{dXAsColumnVector_transpose} as a matrix of shape $\matr{X}$, we get:
+
+\begin{align}
+\frac{\partial L}{\partial \matr{X}} &=
+\begin{bmatrix}
+\frac{\partial L}{\partial z_{1,1}} &
+\frac{\partial L}{\partial z_{2,1}} \\[0.7em]
+\frac{\partial L}{\partial z_{1,2}} &
+\frac{\partial L}{\partial z_{2,2}} \\[0.7em]
+\frac{\partial L}{\partial z_{1,3}} &
+\frac{\partial L}{\partial z_{2,3}} \\[0.7em]
+\end{bmatrix}
+\nonumber \\
+&=
+\transpose{
+\begin{bmatrix}
+\frac{\partial L}{\partial z_{1,1}} & \frac{\partial L}{\partial z_{1,2}} & \frac{\partial L}{\partial z_{1,3}} \\[0.5em]
+\frac{\partial L}{\partial z_{2,1}} & \frac{\partial L}{\partial z_{2,2}} & \frac{\partial L}{\partial z_{2,3}} \\[0.5em]
+\end{bmatrix}}
+\nonumber \\
+&=
+\transpose{\frac{\partial L}{\partial \matr{Z}}}
+\end{align}
+
+\section{Sum along axis=0}
+\subsection{Forward Pass}
+Suppose we are given a matrix $\matr{X}$ of shape $3 \times 2$. Let $\vecr{z}$ = \verb|np.sum(|${\matr{X}}$\verb|, axis=0)|. $\vecr{z}$ will be of shape $1 \times 2$.
+
+\begin{displaymath}
+\matr{X} =
+\begin{bmatrix}
+x_{1,1} & x_{1,2} \\%[0.5em]
+x_{2,1} & x_{2,2} \\%[0.5em]
+x_{3,1} & x_{3,2} \\%[0.5em]
+\end{bmatrix}
+\end{displaymath}
+
+$\vecr{z}$ can be expressed as:
+
+\begin{align}
+\vecr{z} &=
+\begin{bmatrix}
+z_{1,1} & z_{1,2} \\%[0.5em]
+\end{bmatrix}
+\nonumber \\
+&=
+\begin{bmatrix}
+x_{1,1} + x_{2,1} + x_{3,1} &
+x_{1,2} + x_{2,2} + x_{3,2} \\%[0.5em]
+\end{bmatrix}
+\end{align}
+
+\subsection{Backward Pass}
+We have $\frac{\partial L}{\partial \vecr{z}}$ of shape $1 \times 2$.
+
+\begin{displaymath}
+\frac{\partial L}{\partial \matr{Z}} =
+\begin{bmatrix}
+\frac{\partial L}{\partial z_{1,1}} & \frac{\partial L}{\partial z_{1,2}} \\[0.3em]
+\end{bmatrix}
+\end{displaymath}
+
+We now need to compute $\frac{\partial L}{\partial \matr{X}}$. Using chain rule, we get:
+
+\begin{equation} \label{dX_sum_along_axis_0}
+\frac{\partial L}{\partial \matr{X}} = \frac{\partial \vecr{z}}{\partial \matr{X}}\frac{\partial L}{\partial \vecr{z}}
+\end{equation}
+
+\subsubsection{Computing $\frac{\partial L}{\partial \matr{X}}$}
+To compute $\frac{\partial L}{\partial \matr{X}}$, we need to compute $\frac{\partial \vecr{z}}{\partial \matr{X}}$. To make it easy for us to think about and capture the Jacobian in a two dimensional matrix (as opposed to a tensor), we will reshape matrix $\matr{X}$ as well as vector $\vecr{z}$ as column vectors, and compute Jacobians on them. Once we have computed the column vector corresponding to $\frac{\partial L}{\partial \matr{X}}$, we will reshape it back to a matrix with the same shape as $\matr{X}$.
+
+\begin{align}
+\frac{\partial \matr{Z}}{\partial \matr{X}} &=
+\begin{bmatrix}
+\frac{\partial z_{1,1}}{\partial x_{1,1}} & \frac{\partial z_{1,2}}{\partial x_{1,1}} \\[0.7em]
+\frac{\partial z_{1,1}}{\partial x_{1,2}} & \frac{\partial z_{1,2}}{\partial x_{1,2}} \\[0.7em]
+\frac{\partial z_{1,1}}{\partial x_{2,1}} & \frac{\partial z_{1,2}}{\partial x_{2,1}} \\[0.7em]
+\frac{\partial z_{1,1}}{\partial x_{2,2}} & \frac{\partial z_{1,2}}{\partial x_{2,2}} \\[0.7em]
+\frac{\partial z_{1,1}}{\partial x_{3,1}} & \frac{\partial z_{1,2}}{\partial x_{3,1}} \\[0.7em]
+\frac{\partial z_{1,1}}{\partial x_{3,2}} & \frac{\partial z_{1,2}}{\partial x_{3,2}} \\[0.7em]
+\end{bmatrix} \nonumber
+\\ \label{dZbydX_sum_along_axis_0}
+&=
+\begin{bmatrix}
+1 & 0 \\%[0.5em]
+0 & 1 \\%[0.5em]
+1 & 0 \\%[0.5em]
+0 & 1 \\%[0.5em]
+1 & 0 \\%[0.5em]
+0 & 1 \\%[0.5em]
+\end{bmatrix}
+\end{align}
+
+Now, $\frac{\partial L}{\partial \vecr{z}}$ expressed as a column vector will be:
+
+\begin{equation} \label{dZAsColumnVector_sum_along_axis_0}
+\frac{\partial L}{\partial \vecr{z}} =
+\begin{bmatrix}
+\frac{\partial L}{\partial z_{1,1}} \\[0.7em]
+\frac{\partial L}{\partial z_{1,2}} \\[0.7em]
+\end{bmatrix}
+\end{equation}
+
+Plugging equations \ref{dZbydX_sum_along_axis_0} and \ref{dZAsColumnVector_sum_along_axis_0} into equation \ref{dX_sum_along_axis_0}, we get:
+
+\begin{align}
+\frac{\partial L}{\partial \matr{X}} &=
+\begin{bmatrix}
+1 & 0 \\%[0.5em]
+0 & 1 \\%[0.5em]
+1 & 0 \\%[0.5em]
+0 & 1 \\%[0.5em]
+1 & 0 \\%[0.5em]
+0 & 1 \\%[0.5em]
+\end{bmatrix}
+\begin{bmatrix}
+\frac{\partial L}{\partial z_{1,1}} \\[0.7em]
+\frac{\partial L}{\partial z_{1,2}} \\[0.7em]
+\end{bmatrix}
+\nonumber \\
+&=
+\begin{bmatrix}
+\frac{\partial L}{\partial z_{1,1}} \\[0.7em]
+\frac{\partial L}{\partial z_{1,2}} \\[0.7em]
+\frac{\partial L}{\partial z_{1,1}} \\[0.7em]
+\frac{\partial L}{\partial z_{1,2}} \\[0.7em]
+\frac{\partial L}{\partial z_{1,1}} \\[0.7em]
+\frac{\partial L}{\partial z_{1,2}} \\[0.7em]
+\end{bmatrix} \label{dXAsColumnVector_sum_along_axis_0}
+\end{align}
+
+Now, reshaping column vector in equation \ref{dXAsColumnVector_sum_along_axis_0} as a matrix of shape $\matr{X}$, we get:
+
+\begin{align}
+\frac{\partial L}{\partial \matr{X}} &=
+\begin{bmatrix}
+\frac{\partial L}{\partial z_{1,1}} &
+\frac{\partial L}{\partial z_{1,2}} \\[0.7em]
+\frac{\partial L}{\partial z_{1,1}} &
+\frac{\partial L}{\partial z_{1,2}} \\[0.7em]
+\frac{\partial L}{\partial z_{1,1}} &
+\frac{\partial L}{\partial z_{1,2}} \\[0.7em]
+\end{bmatrix} \nonumber
+\\
+&=
+\begin{bmatrix}
+1 \\
+1 \\
+1 \\
+\end{bmatrix}
+\begin{bmatrix}
+\frac{\partial L}{\partial z_{1,1}} & \frac{\partial L}{\partial z_{1,2}} \\[0.3em]
+\end{bmatrix} \nonumber
+\\
+&=
+\mathbf{1}_{3,1} \frac{\partial L}{\partial \vecr{z}} \nonumber
+\\
+&=
+\mathbf{1}_{\text{rows}(\matr{X}),1} \frac{\partial L}{\partial \vecr{z}}
+\end{align}
+
+\section{Sum along axis=1}
+\subsection{Forward Pass}
+Suppose we are given a matrix $\matr{X}$ of shape $3 \times 2$. Let $\vecr{z}$ = \verb|np.sum(|${\matr{X}}$\verb|, axis=1)|. $\vecr{z}$ will be of shape $3 \times 1$.
+
+\begin{displaymath}
+\matr{X} =
+\begin{bmatrix}
+x_{1,1} & x_{1,2} \\%[0.5em]
+x_{2,1} & x_{2,2} \\%[0.5em]
+x_{3,1} & x_{3,2} \\%[0.5em]
+\end{bmatrix}
+\end{displaymath}
+
+$\vecr{z}$ can be expressed as:
+
+\begin{align}
+\vecr{z} &=
+\begin{bmatrix}
+z_{1,1} \\
+z_{2,1} \\
+z_{3,1} \\
+\end{bmatrix}
+\nonumber \\
+&=
+\begin{bmatrix}
+x_{1,1} + x_{1,2} \\
+x_{2,1} + x_{2,2} \\
+x_{3,1} + x_{3,2} \\
+\end{bmatrix}
+\end{align}
+
+\subsection{Backward Pass}
+We have $\frac{\partial L}{\partial \vecr{z}}$ of shape $3 \times 1$.
+
+\begin{align}
+\frac{\partial L}{\partial \matr{Z}} =
+\begin{bmatrix}
+\frac{\partial L}{\partial z_{1,1}} \\[0.7em]
+\frac{\partial L}{\partial z_{2,1}} \\[0.7em]
+\frac{\partial L}{\partial z_{3,1}} \\[0.7em]
+\end{bmatrix} \label{dZAsColumnVector_sum_along_axis_1}
+\end{align}
+
+We now need to compute $\frac{\partial L}{\partial \matr{X}}$. Using chain rule, we get:
+
+\begin{equation} \label{dX_sum_along_axis_1}
+\frac{\partial L}{\partial \matr{X}} = \frac{\partial \vecr{z}}{\partial \matr{X}}\frac{\partial L}{\partial \vecr{z}}
+\end{equation}
+
+\subsubsection{Computing $\frac{\partial L}{\partial \matr{X}}$}
+To compute $\frac{\partial L}{\partial \matr{X}}$, we need to compute $\frac{\partial \vecr{z}}{\partial \matr{X}}$. To make it easy for us to think about and capture the Jacobian in a two dimensional matrix (as opposed to a tensor), we will reshape matrix $\matr{X}$ as a column vector, and compute Jacobians on the column vectors instead. Once we have computed the column vector corresponding to $\frac{\partial L}{\partial \matr{X}}$, we will reshape it back to a matrix with the same shape as $\matr{X}$.
+
+\begin{align}
+\frac{\partial \matr{Z}}{\partial \matr{X}} &=
+\begin{bmatrix}
+\frac{\partial z_{1,1}}{\partial x_{1,1}} & \frac{\partial z_{2,1}}{\partial x_{1,1}} & \frac{\partial z_{3,1}}{\partial x_{1,1}}\\[0.7em]
+\frac{\partial z_{1,1}}{\partial x_{1,2}} & \frac{\partial z_{2,1}}{\partial x_{1,2}} & \frac{\partial z_{3,1}}{\partial x_{1,2}} \\[0.7em]
+\frac{\partial z_{1,1}}{\partial x_{2,1}} & \frac{\partial z_{2,1}}{\partial x_{2,1}} & \frac{\partial z_{3,1}}{\partial x_{2,1}} \\[0.7em]
+\frac{\partial z_{1,1}}{\partial x_{2,2}} & \frac{\partial z_{2,1}}{\partial x_{2,2}} & \frac{\partial z_{3,1}}{\partial x_{2,2}} \\[0.7em]
+\frac{\partial z_{1,1}}{\partial x_{3,1}} & \frac{\partial z_{2,1}}{\partial x_{3,1}} & \frac{\partial z_{3,1}}{\partial x_{3,1}} \\[0.7em]
+\frac{\partial z_{1,1}}{\partial x_{3,2}} & \frac{\partial z_{2,1}}{\partial x_{3,2}} & \frac{\partial z_{3,1}}{\partial x_{3,2}} \\[0.7em]
+\end{bmatrix} \nonumber
+\\ \label{dZbydX_sum_along_axis_1}
+&=
+\begin{bmatrix}
+1 & 0 & 0 \\%[0.5em]
+1 & 0 & 0 \\%[0.5em]
+0 & 1 & 0 \\%[0.5em]
+0 & 1 & 0 \\%[0.5em]
+0 & 0 & 1 \\%[0.5em]
+0 & 0 & 1 \\%[0.5em]
+\end{bmatrix}
+\end{align}
+
+Plugging equations \ref{dZbydX_sum_along_axis_1} and \ref{dZAsColumnVector_sum_along_axis_1} into equation \ref{dX_sum_along_axis_1}, we get:
+
+\begin{align}
+\frac{\partial L}{\partial \matr{X}} &=
+\begin{bmatrix}
+1 & 0 & 0 \\%[0.5em]
+1 & 0 & 0 \\%[0.5em]
+0 & 1 & 0 \\%[0.5em]
+0 & 1 & 0 \\%[0.5em]
+0 & 0 & 1 \\%[0.5em]
+0 & 0 & 1 \\%[0.5em]
+\end{bmatrix}
+\begin{bmatrix}
+\frac{\partial L}{\partial z_{1,1}} \\[0.7em]
+\frac{\partial L}{\partial z_{2,1}} \\[0.7em]
+\frac{\partial L}{\partial z_{3,1}} \\[0.7em]
+\end{bmatrix}
+\nonumber \\
+&=
+\begin{bmatrix}
+\frac{\partial L}{\partial z_{1,1}} \\[0.7em]
+\frac{\partial L}{\partial z_{1,1}} \\[0.7em]
+\frac{\partial L}{\partial z_{2,1}} \\[0.7em]
+\frac{\partial L}{\partial z_{2,1}} \\[0.7em]
+\frac{\partial L}{\partial z_{3,1}} \\[0.7em]
+\frac{\partial L}{\partial z_{3,1}} \\[0.7em]
+\end{bmatrix} \label{dXAsColumnVector_sum_along_axis_1}
+\end{align}
+
+Now, reshaping column vector in equation \ref{dXAsColumnVector_sum_along_axis_1} as a matrix of shape $\matr{X}$, we get:
+
+\begin{align}
+\frac{\partial L}{\partial \matr{X}} &=
+\begin{bmatrix}
+\frac{\partial L}{\partial z_{1,1}} &
+\frac{\partial L}{\partial z_{1,1}} \\[0.7em]
+\frac{\partial L}{\partial z_{2,1}} &
+\frac{\partial L}{\partial z_{2,1}} \\[0.7em]
+\frac{\partial L}{\partial z_{3,1}} &
+\frac{\partial L}{\partial z_{3,1}} \\[0.7em]
+\end{bmatrix} \nonumber
+\\
+&=
+\begin{bmatrix}
+\frac{\partial L}{\partial z_{1,1}} \\[0.7em]
+\frac{\partial L}{\partial z_{2,1}} \\[0.7em]
+\frac{\partial L}{\partial z_{3,1}} \\[0.7em]
+\end{bmatrix}
+\begin{bmatrix}
+1 & 1 \\%[0.3em]
+\end{bmatrix} \nonumber
+\\
+&=
+\frac{\partial L}{\partial \vecr{z}} \mathbf{1}_{1,2} \nonumber
+\\
+&=
+\frac{\partial L}{\partial \vecr{z}} \mathbf{1}_{1, \text{cols}(\matr{X})}
+\end{align}
+
+\section{Broadcasting a column vector}
+\subsection{Forward Pass}
+Suppose we are given a vector $\vecr{x}$ of shape $3 \times 1$. Let $\matr{Z} = \vecr{x} \mathbf{1}_{1,\text{C}}$. $\matr{Z}$ will be of shape $3 \times \text{C}$. Let us suppose that C = 2.
+
+\begin{displaymath}
+\matr{X} =
+\begin{bmatrix}
+x_{1,1} \\%[0.5em]
+x_{2,1} \\%[0.5em]
+x_{3,1} \\%[0.5em]
+\end{bmatrix}
+\end{displaymath}
+
+$\vecr{z}$ can be expressed as:
+
+\begin{align}
+\vecr{z} &=
+\begin{bmatrix}
+z_{1,1} & z_{1,2} \\
+z_{2,1} & z_{2,2} \\
+z_{3,1} & z_{2,3} \\
+\end{bmatrix}
+\nonumber \\
+&=
+\begin{bmatrix}
+x_{1,1} & x_{1,1} \\
+x_{2,1} & x_{2,1} \\
+x_{3,1} & x_{3,1} \\
+\end{bmatrix}
+\end{align}
+
+\subsection{Backward Pass}
+We have $\frac{\partial L}{\partial \matr{Z}}$ of shape $3 \times 2$.
+
+\begin{align}
+\frac{\partial L}{\partial \matr{Z}} =
+\begin{bmatrix}
+\frac{\partial L}{\partial z_{1,1}} & \frac{\partial L}{\partial z_{1,2}} \\[0.7em]
+\frac{\partial L}{\partial z_{2,1}} & \frac{\partial L}{\partial z_{2,2}} \\[0.7em]
+\frac{\partial L}{\partial z_{3,1}} & \frac{\partial L}{\partial z_{3,2}} \\[0.7em]
+\end{bmatrix} \label{dZAsColumnVector_column_vector}
+\end{align}
+
+We now need to compute $\frac{\partial L}{\partial \vecr{x}}$. Using chain rule, we get:
+
+\begin{equation} \label{dX_broadcast_column_vector}
+\frac{\partial L}{\partial \vecr{x}} = \frac{\partial \matr{Z}}{\partial \vecr{x}}\frac{\partial L}{\partial \matr{Z}}
+\end{equation}
+
+\subsubsection{Computing $\frac{\partial L}{\partial \vecr{x}}$}
+To compute $\frac{\partial L}{\partial \vecr{x}}$, we need to compute $\frac{\partial \matr{Z}}{\partial \vecr{x}}$. To make it easy for us to think about and capture the Jacobian in a two dimensional matrix (as opposed to a tensor), we will reshape matrix $\matr{Z}$ as a column vector, and compute Jacobians on the column vectors instead.
+
+\begin{align}
+\frac{\partial \matr{Z}}{\partial \vecr{x}} &=
+\begin{bmatrix}
+\frac{\partial z_{1,1}}{\partial x_{1,1}} & \frac{\partial z_{1,2}}{\partial x_{1,1}} & \frac{\partial z_{2,1}}{\partial x_{1,1}} & \frac{\partial z_{2,2}}{\partial x_{1,1}} & \frac{\partial z_{3,1}}{\partial x_{1,1}} & \frac{\partial z_{3,2}}{\partial x_{1,1}} \\[0.7em]
+\frac{\partial z_{1,1}}{\partial x_{2,1}} & \frac{\partial z_{1,2}}{\partial x_{2,1}} & \frac{\partial z_{2,1}}{\partial x_{2,1}} & \frac{\partial z_{2,2}}{\partial x_{2,1}} & \frac{\partial z_{3,1}}{\partial x_{2,1}} & \frac{\partial z_{3,2}}{\partial x_{2,1}} \\[0.7em]
+\frac{\partial z_{1,1}}{\partial x_{3,1}} & \frac{\partial z_{1,2}}{\partial x_{3,1}} & \frac{\partial z_{2,1}}{\partial x_{3,1}} & \frac{\partial z_{2,2}}{\partial x_{3,1}} & \frac{\partial z_{3,1}}{\partial x_{3,1}} & \frac{\partial z_{3,2}}{\partial x_{3,1}} \\[0.7em]
+\end{bmatrix} \nonumber
+\\ \label{dZbydX_broadcast_column_vector}
+&=
+\begin{bmatrix}
+1 & 1 & 0 & 0 & 0 & 0\\%[0.5em]
+0 & 0 & 1 & 1 & 0 & 0\\%[0.5em]
+0 & 0 & 0 & 0 & 1 & 1\\%[0.5em]
+\end{bmatrix}
+\end{align}
+
+Now, $\frac{\partial L}{\partial \matr{Z}}$ expressed as a column vector will be:
+
+\begin{equation} \label{dZAsColumnVector_broadcast_column_vector}
+\frac{\partial L}{\partial \matr{Z}} =
+\begin{bmatrix}
+\frac{\partial L}{\partial z_{1,1}} \\[0.7em]
+\frac{\partial L}{\partial z_{1,2}} \\[0.7em]
+\frac{\partial L}{\partial z_{2,1}} \\[0.7em]
+\frac{\partial L}{\partial z_{2,2}} \\[0.7em]
+\frac{\partial L}{\partial z_{3,1}} \\[0.7em]
+\frac{\partial L}{\partial z_{3,2}} \\[0.7em]
+\end{bmatrix}
+\end{equation}
+
+Plugging equations \ref{dZbydX_broadcast_column_vector} and \ref{dZAsColumnVector_broadcast_column_vector} into equation \ref{dX_broadcast_column_vector}, we get:
+
+\begin{align}
+\frac{\partial L}{\partial \vecr{x}} &=
+\begin{bmatrix}
+1 & 1 & 0 & 0 & 0 & 0\\%[0.5em]
+0 & 0 & 1 & 1 & 0 & 0\\%[0.5em]
+0 & 0 & 0 & 0 & 1 & 1\\%[0.5em]
+\end{bmatrix}
+\begin{bmatrix}
+\frac{\partial L}{\partial z_{1,1}} \\[0.7em]
+\frac{\partial L}{\partial z_{1,2}} \\[0.7em]
+\frac{\partial L}{\partial z_{2,1}} \\[0.7em]
+\frac{\partial L}{\partial z_{2,2}} \\[0.7em]
+\frac{\partial L}{\partial z_{3,1}} \\[0.7em]
+\frac{\partial L}{\partial z_{3,2}} \\[0.7em]
+\end{bmatrix}
+\nonumber \\
+&=
+\begin{bmatrix}
+\frac{\partial L}{\partial z_{1,1}} +
+\frac{\partial L}{\partial z_{1,2}} \\[0.7em]
+\frac{\partial L}{\partial z_{2,1}} +
+\frac{\partial L}{\partial z_{2,2}} \\[0.7em]
+\frac{\partial L}{\partial z_{3,1}} +
+\frac{\partial L}{\partial z_{3,2}} \\[0.7em]
+\end{bmatrix} \nonumber
+\\
+&=
+\begin{bmatrix}
+\frac{\partial L}{\partial z_{1,1}} +
+\frac{\partial L}{\partial z_{1,2}} \\[0.7em]
+\frac{\partial L}{\partial z_{2,1}} +
+\frac{\partial L}{\partial z_{2,2}} \\[0.7em]
+\frac{\partial L}{\partial z_{3,1}} +
+\frac{\partial L}{\partial z_{3,2}} \\[0.7em]
+\end{bmatrix} \nonumber
+\\
+&=
+\begin{bmatrix}
+\frac{\partial L}{\partial z_{1,1}} & \frac{\partial L}{\partial z_{1,2}} \\[0.7em]
+\frac{\partial L}{\partial z_{2,1}} & \frac{\partial L}{\partial z_{2,2}} \\[0.7em]
+\frac{\partial L}{\partial z_{3,1}} & \frac{\partial L}{\partial z_{3,2}} \\[0.7em]
+\end{bmatrix}
+\begin{bmatrix}
+1 \\
+1 \\
+\end{bmatrix} \nonumber
+\\
+&=
+\frac{\partial L}{\partial \matr{Z}} \mathbf{1}_{\text{C},1} \nonumber
+\\
+&= \mathtt{np.sum(} \matr{Z} \mathtt{, axis=1)}
+\end{align}
+
+\section{Broadcasting a row vector}
+\subsection{Forward Pass}
+Suppose we are given a vector $\vecr{x}$ of shape $1 \times 3$. Let $\matr{Z} = \mathbf{1}_{\text{R},1} \vecr{x}$. $\matr{Z}$ will be of shape $\text{R} \times 3$. Let us suppose that R = 2.
+
+\begin{displaymath}
+\matr{X} =
+\begin{bmatrix}
+x_{1,1} & x_{1,2} & x_{1,3} \\%[0.5em]
+\end{bmatrix}
+\end{displaymath}
+
+$\matr{Z}$ can be expressed as:
+
+\begin{align}
+\vecr{z} &=
+\begin{bmatrix}
+z_{1,1} & z_{1,2} & z_{1,3} \\
+z_{2,1} & z_{2,2} & z_{2,3} \\
+\end{bmatrix}
+\nonumber \\
+&=
+\begin{bmatrix}
+x_{1,1} & x_{1,2} & x_{1,3} \\%[0.5em]
+x_{1,1} & x_{1,2} & x_{1,3} \\%[0.5em]
+\end{bmatrix}
+\end{align}
+
+\subsection{Backward Pass}
+We have $\frac{\partial L}{\partial \matr{Z}}$ of shape $2 \times 3$.
+
+\begin{align}
+\frac{\partial L}{\partial \matr{Z}} =
+\begin{bmatrix}
+\frac{\partial L}{\partial z_{1,1}} & \frac{\partial L}{\partial z_{1,2}} & \frac{\partial L}{\partial z_{1,3}}\\[0.7em]
+\frac{\partial L}{\partial z_{2,1}} & \frac{\partial L}{\partial z_{2,2}} & \frac{\partial L}{\partial z_{2,3}}\\[0.7em]
+\end{bmatrix}
+\end{align}
+
+We now need to compute $\frac{\partial L}{\partial \vecr{x}}$. Using chain rule, we get:
+
+\begin{equation} \label{dX_broadcast_row_vector}
+\frac{\partial L}{\partial \vecr{x}} = \frac{\partial \matr{Z}}{\partial \vecr{x}}\frac{\partial L}{\partial \matr{Z}}
+\end{equation}
+
+\subsubsection{Computing $\frac{\partial L}{\partial \vecr{x}}$}
+To compute $\frac{\partial L}{\partial \vecr{x}}$, we need to compute $\frac{\partial \matr{Z}}{\partial \vecr{x}}$. To make it easy for us to think about and capture the Jacobian in a two dimensional matrix (as opposed to a tensor), we will reshape matrix $\matr{Z}$ as well as vector $\vecr{x}$ as a column vector, and compute Jacobians on the column vectors instead.
+
+\begin{align}
+\frac{\partial \matr{Z}}{\partial \vecr{x}} &=
+\begin{bmatrix}
+\frac{\partial z_{1,1}}{\partial x_{1,1}} & \frac{\partial z_{1,2}}{\partial x_{1,1}} & \frac{\partial z_{1,3}}{\partial x_{1,1}} & \frac{\partial z_{2,1}}{\partial x_{1,1}} & \frac{\partial z_{2,2}}{\partial x_{1,1}} & \frac{\partial z_{2,3}}{\partial x_{1,1}} \\[0.7em]
+\frac{\partial z_{1,1}}{\partial x_{1,2}} & \frac{\partial z_{1,2}}{\partial x_{1,2}} & \frac{\partial z_{1,3}}{\partial x_{1,2}} & \frac{\partial z_{2,1}}{\partial x_{1,2}} & \frac{\partial z_{2,2}}{\partial x_{1,2}} & \frac{\partial z_{2,3}}{\partial x_{1,2}} \\[0.7em]
+\frac{\partial z_{1,1}}{\partial x_{1,3}} & \frac{\partial z_{1,2}}{\partial x_{1,3}} & \frac{\partial z_{1,3}}{\partial x_{1,3}} & \frac{\partial z_{2,1}}{\partial x_{1,3}} & \frac{\partial z_{2,2}}{\partial x_{1,3}} & \frac{\partial z_{2,3}}{\partial x_{1,3}} \\[0.7em]
+\end{bmatrix} \nonumber
+\\ \label{dZbydX_broadcast_row_vector}
+&=
+\begin{bmatrix}
+1 & 0 & 0 & 1 & 0 & 0\\%[0.5em]
+0 & 1 & 0 & 0 & 1 & 0\\%[0.5em]
+0 & 0 & 1 & 0 & 0 & 1\\%[0.5em]
+\end{bmatrix}
+\end{align}
+
+Now, $\frac{\partial L}{\partial \matr{Z}}$ expressed as a column vector will be:
+
+\begin{equation} \label{dZAsColumnVector_broadcast_row_vector}
+\frac{\partial L}{\partial \matr{Z}} =
+\begin{bmatrix}
+\frac{\partial L}{\partial z_{1,1}} \\[0.7em]
+\frac{\partial L}{\partial z_{1,2}} \\[0.7em]
+\frac{\partial L}{\partial z_{1,3}} \\[0.7em]
+\frac{\partial L}{\partial z_{2,1}} \\[0.7em]
+\frac{\partial L}{\partial z_{2,2}} \\[0.7em]
+\frac{\partial L}{\partial z_{2,3}} \\[0.7em]
+\end{bmatrix}
+\end{equation}
+
+Plugging equations \ref{dZbydX_broadcast_row_vector} and \ref{dZAsColumnVector_broadcast_row_vector} into equation \ref{dX_broadcast_row_vector}, we get:
+
+\begin{align}
+\frac{\partial L}{\partial \vecr{x}} &=
+\begin{bmatrix}
+1 & 0 & 0 & 1 & 0 & 0\\%[0.5em]
+0 & 1 & 0 & 0 & 1 & 0\\%[0.5em]
+0 & 0 & 1 & 0 & 0 & 1\\%[0.5em]
+\end{bmatrix}
+\begin{bmatrix}
+\frac{\partial L}{\partial z_{1,1}} \\[0.7em]
+\frac{\partial L}{\partial z_{1,2}} \\[0.7em]
+\frac{\partial L}{\partial z_{1,3}} \\[0.7em]
+\frac{\partial L}{\partial z_{2,1}} \\[0.7em]
+\frac{\partial L}{\partial z_{2,2}} \\[0.7em]
+\frac{\partial L}{\partial z_{2,3}} \\[0.7em]
+\end{bmatrix}
+\nonumber \\
+&=
+\begin{bmatrix}
+\frac{\partial L}{\partial z_{1,1}} +
+\frac{\partial L}{\partial z_{2,1}} \\[0.7em]
+\frac{\partial L}{\partial z_{1,2}} +
+\frac{\partial L}{\partial z_{2,2}} \\[0.7em]
+\frac{\partial L}{\partial z_{1,3}} +
+\frac{\partial L}{\partial z_{2,3}} \\[0.7em]
+\end{bmatrix} \label{dXAsColumnVector_broadcast_row_vector}
+\end{align}
+
+Now reshaping $\frac{\partial L}{\partial \vecr{x}}$ from column vector of shape $3 \times 1$ in equation \ref{dXAsColumnVector_broadcast_row_vector} into row vector of shape $1 \times 3$ we get:
+
+\begin{align}
+\frac{\partial L}{\partial \vecr{x}} &=
+\begin{bmatrix}
+\frac{\partial L}{\partial z_{1,1}} +
+\frac{\partial L}{\partial z_{2,1}} &
+\frac{\partial L}{\partial z_{1,2}} +
+\frac{\partial L}{\partial z_{2,2}} &
+\frac{\partial L}{\partial z_{1,3}} +
+\frac{\partial L}{\partial z_{2,3}} \\[0.7em]
+\end{bmatrix}
+\nonumber \\
+&=
+\mathbf{1}_{1, \text{2}}
+\begin{bmatrix}
+\frac{\partial L}{\partial z_{1,1}} & \frac{\partial L}{\partial z_{1,2}} & \frac{\partial L}{\partial z_{1,3}}\\[0.7em]
+\frac{\partial L}{\partial z_{2,1}} & \frac{\partial L}{\partial z_{2,2}} & \frac{\partial L}{\partial z_{2,3}}\\[0.7em]
+\end{bmatrix}
+\nonumber \\
+&=
+\mathbf{1}_{1, \text{R}} \frac{\partial L}{\partial \matr{Z}}
+\nonumber \\
+&=
+\mathtt{np.sum(} \matr{Z} \mathtt{, axis=0)}
+\end{align}
+
+\end{document}

--- a/student-contributions/BackPropagationBasicMatrixOperations.tex
+++ b/student-contributions/BackPropagationBasicMatrixOperations.tex
@@ -1,13 +1,36 @@
 \documentclass{article}
 \usepackage[utf8]{inputenc}
-\usepackage{amsmath} % Required for display matrices.
+\usepackage{mathtools} % Required for display matrices. Extension on top of amsmath package.
 \usepackage{bm} % for rendering vectors correctly
+\usepackage{xcolor}
 \usepackage{amssymb} % for rendering dimension symbol R
 \usepackage[nocfg,notintoc]{nomencl}
 \makenomenclature
 \usepackage{booktabs}
 %\renewcommand{\arraystretch}{2.0} % affects matrices too.
-\usepackage[letterpaper, margin=0.8in]{geometry}
+\usepackage[letterpaper, hmargin=0.8in]{geometry}
+\usepackage{fancyhdr}
+\pagestyle{fancy}
+
+% with this we ensure that the chapter and section
+% headings are in lowercase.
+%\renewcommand{\chaptermark}[1]{\markboth{#1}{}}
+\renewcommand{\sectionmark}[1]{%
+\markright{\thesection\ #1}}
+\fancyhf{} % delete current header and footer
+\fancyhead[L,R]{\bfseries\thepage}
+\fancyhead[LO]{\bfseries\rightmark}
+%\fancyhead[RE]{\bfseries\leftmark}
+\renewcommand{\headrulewidth}{0.5pt}
+\renewcommand{\footrulewidth}{0pt}
+\addtolength{\headheight}{0.5pt} % space for the rule
+\fancypagestyle{plain}{%
+\fancyhead{} % get rid of headers on plain pages
+\renewcommand{\headrulewidth}{0pt} % and the line
+}
+
+% hyperref package doesn't seem to be working.
+
 
 \renewcommand{\nomname}{} % We don't to use any word here.
 \newcommand{\transpose}[1]{#1^\top}
@@ -16,7 +39,23 @@
 %\newcommand{\matr}[1]{#1}          % pure math version
 %\newcommand{\matr}[1]{\bm{#1}}     % ISO complying version
 
-\title{CS231N: Backpropagation - Basic Matrix Operations}
+\newcommand{\eqncomment}[1]{
+\footnotesize
+\textcolor{gray}{
+\begin{pmatrix*}[l]
+\text{#1}
+\end{pmatrix*}
+}}
+\newcommand{\longeqncomment}[2]
+{\footnotesize
+\textcolor{gray}{
+\begin{pmatrix*}[l]
+\text{#1} \\
+\text{#2}
+\end{pmatrix*}
+}}
+
+\title{CS231N: Backpropagation - Vector and Matrix Calculus}
 \author{
   Ashish Jain \\
   Stanford University \\
@@ -25,15 +64,24 @@
 \date{\today}
 
 \begin{document}
-
+\pagestyle{empty}
 \maketitle
 
 \tableofcontents
 
+\newpage
+\pagestyle{fancy}
 \section{Introduction}
-The intent of this document is to show using small non-trivial examples how and why certain backpropagation operations reduce to the equations they reduce to for basic operations such as matrix multiplication, some element-wise operation on a matrix, element-wise operations between two matrices and broadcasting of a vector to a matrix. The example matrices and vectors are deliberately kept small to ensure one can verify on paper if the contents of this document are correct.
+\subsection{Intended Audience}
+This document is primarily targeted towards CS231N students who don't have a formal background in vector and matrix calculus.
 
-Each section from section \ref{Matrix Multiplication} onwards is written independently of each other, and therefore, you can directly jump to a section of your interest.
+\subsection{Learning Goals}
+CS231N assignments have a heavy emphasis on vector and matrix calculus. Several different notation and layout conventions are popular in the literature which can be confusing and overwhelming for students just starting out with vector and matrix calculus. This document firmly aligns and sticks with the layout conventions for matrix calculus taught in CS231N lectures. This document hopes to bring the students who lack a formal background in vector and matrix calculus up to speed as well as serve as a reference while solving the various assignments. 
+
+\subsection{Content}
+Through small non-trivial examples, we show how and why certain backpropagation operations reduce to the equations they reduce to for basic operations such as matrix multiplication, some element-wise operation on a matrix, element-wise operations between two matrices, reductions of a matrix to a vector and broadcasting of a vector to a matrix. The example matrices and vectors are deliberately kept small to ensure one can convince oneself or alternately verify on paper if the contents of this document are correct (please feel free to submit bugs or corrections). The examples considered while small are kept as general as possible throughout the derivations. Therefore, a motivated student can easily extend these examples to general proofs.
+
+Each section from section \ref{Matrix Multiplication} onward is written independently of each other, and therefore, you can directly jump to a section of your interest.
 
 \section{Nomenclature}
 \vspace{-2.5em}
@@ -50,14 +98,16 @@ Given a vector $\vecr{y}$ where $\bm{y} \in \mathbb{R}^{m}$ and a vector $\bm{x}
 
 For example, if $\bm{x} \in \mathbb{R}^{3}$ and $\bm{y} \in \mathbb{R}^{2}$ then:
 
-\begin{displaymath}
-\frac{\partial \bm{y}}{\partial \bm{x}} = 
+\begin{flalign}
+\frac{\partial \bm{y}}{\partial \bm{x}} &= 
 \begin{bmatrix}
 \frac{\partial y_{1}}{\partial x_{1}} & \frac{\partial y_{2}}{\partial x_{1}} \\[0.5em]
 \frac{\partial y_{1}}{\partial x_{2}} & \frac{\partial y_{2}}{\partial x_{2}} \\[0.5em]
 \frac{\partial y_{1}}{\partial x_{3}} & \frac{\partial y_{2}}{\partial x_{3}} \\[0.5em]
 \end{bmatrix}
-\end{displaymath}
+& \longeqncomment{Denominator layout where layout is according to $\transpose{\vecr{y}}$ across axis 1 and $\vecr{x}$ across axis 0.}{In other words, the elements of $\vecr{y}$ are laid out in columns and the elements of $\vecr{x}$ are laid out in rows.}
+\nonumber
+\end{flalign}
 
 \section{Summary}
 \small
@@ -95,7 +145,7 @@ $\frac{\partial L}{\partial \matr{X}}=\frac{\partial L}{\partial \vecr{z}} \math
 $\frac{\partial L}{\partial \vecr{x}}=\mathtt{np.sum(} \frac{\partial L}{\partial \matr{Z}} \mathtt{, axis=1)}$ & \\[1em]
 
 9 & Broadcasting a row vector & $\matr{Z} = \mathbf{1}_{\text{R},1} \vecr{x}$ &
-$\frac{\partial L}{\partial \vecr{x}}=\mathtt{np.sum(} \frac{\partial L}{\partial \matr{Z}} \mathtt{, axis=0)}$ & \\[1em]
+$\frac{\partial L}{\partial \vecr{x}}=\mathtt{np.sum(} \frac{\partial L}{\partial \matr{Z}} \mathtt{, axis=0)}$ & \\[0.3em]
 \bottomrule
 \end{tabular}
 
@@ -145,65 +195,67 @@ Index & Name & $\matr{Z}$/$\vecr{z}$ &
 \normalsize
 \section{Matrix Multiplication} \label{Matrix Multiplication}
 \subsection{Forward Pass}
-Let $\matr{X}$ be a $2 \times 3$ matrix, and let $\matr{Y}$ be a $3 \times 2$ matrix. Let $\matr{Z} = \matr{X}\matr{Y}$. $\matr{Z}$ will be of shape $2 \times 2$.
+Let $\matr{X}$ be a $2 \times 3$ matrix, and let $\matr{Y}$ be a $3 \times 2$ matrix. Let $\matr{Z} = \matr{X}\matr{Y}$.
 
-\begin{displaymath}
-\matr{X} =
+\begin{flalign}
+\matr{X} &=
 \begin{bmatrix}
 x_{1,1} & x_{1,2} & x_{1,3} \\%[0.5em]
 x_{2,1} & x_{2,2} & x_{2,3} \\%[0.5em]
-\end{bmatrix}
-\end{displaymath}
+\end{bmatrix} &
+\end{flalign}
 
-\begin{displaymath}
-\matr{Y} =
+\begin{flalign}
+\matr{Y} &=
 \begin{bmatrix}
 y_{1,1} & y_{1,2} \\%[0.5em]
 y_{2,1} & y_{2,2} \\%[0.5em]
 y_{3,1} & y_{3,2} \\%[0.5em]
-\end{bmatrix}
-\end{displaymath}
+\end{bmatrix} &
+\end{flalign}
 
-Given $\matr{Z} = \matr{X}\matr{Y}$, Z is a $2 \times 2$ matrix which can be expressed as:
+\vspace{1em}
+\noindent Given $\matr{Z} = \matr{X}\matr{Y}$, Z is a $2 \times 2$ matrix which can be expressed as:
 
-\begin{align}
+\begin{flalign}
 \matr{Z} &= \begin{bmatrix}
 z_{1,1} & z_{1,2}\\[0.5em]
 z_{2,1} & z_{2,2}\\[0.5em]
 \end{bmatrix}
+&
 \\
 &=
 \begin{bmatrix}
 x_{1,1}.y_{1,1} + x_{1,2}.y_{2,1} + x_{1,3}.y_{3,1} & x_{1,1}.y_{1,2} + x_{1,2}.y_{2,2} + x_{1,3}.y_{3,2}\\[0.5em]
 x_{2,1}.y_{1,1} + x_{2,2}.y_{2,1} + x_{2,3}.y_{3,1} & x_{2,1}.y_{1,2} + x_{2,2}.y_{2,2} + x_{2,3}.y_{3,2}\\[0.5em]
 \end{bmatrix}
-\end{align}
+\end{flalign}
 
 \subsection{Backward Pass}
-We have $\frac{\partial L}{\partial \matr{Z}}$ of shape $2 \times 2$.
+We are given $\frac{\partial L}{\partial \matr{Z}}$. It will be of shape $2 \times 2$.
 
-\begin{displaymath}
-\frac{\partial L}{\partial \matr{Z}} =
+\begin{flalign}
+\frac{\partial L}{\partial \matr{Z}} &=
 \begin{bmatrix}
 \frac{\partial L}{\partial z_{1,1}} & \frac{\partial L}{\partial z_{1,2}} \\[0.5em]
 \frac{\partial L}{\partial z_{2,1}} & \frac{\partial L}{\partial z_{2,2}} \\[0.5em]
-\end{bmatrix}
-\end{displaymath}
+\end{bmatrix} & \eqncomment{$\frac{\partial L}{\partial \matr{Z}}$ is the same shape as $\matr{Z}$ as $L$ is a scalar}
+\end{flalign}
 
-We now need to compute $\frac{\partial L}{\partial \matr{X}}$ and $\frac{\partial L}{\partial \matr{Y}}$. Using chain rule, we get:
+\noindent We need to compute $\frac{\partial L}{\partial \matr{X}}$ and $\frac{\partial L}{\partial \matr{Y}}$. Using chain rule, we get:
 
-\begin{equation} \label{dX}
-\frac{\partial L}{\partial \matr{X}} = \frac{\partial \matr{Z}}{\partial \matr{X}}\frac{\partial L}{\partial \matr{Z}}
-\end{equation}
+\begin{flalign} \label{dX}
+\frac{\partial L}{\partial \matr{X}} &= \frac{\partial \matr{Z}}{\partial \matr{X}}\frac{\partial L}{\partial \matr{Z}} &
+\end{flalign}
 
-\begin{equation} \label{dY}
-\frac{\partial L}{\partial \matr{Y}} = \frac{\partial \matr{Z}}{\partial \matr{Y}}\frac{\partial L}{\partial \matr{Z}}
-\end{equation}
+\begin{flalign} \label{dY}
+\frac{\partial L}{\partial \matr{Y}} &= \frac{\partial \matr{Z}}{\partial \matr{Y}}\frac{\partial L}{\partial \matr{Z}} &
+\end{flalign}
 
 \subsubsection{Computing $\frac{\partial L}{\partial \matr{X}}$}
 To compute $\frac{\partial L}{\partial \matr{X}}$, we need to compute $\frac{\partial \matr{Z}}{\partial \matr{X}}$. To make it easy for us to think about and capture the Jacobian in a two dimensional matrix (as opposed to a tensor), we will reshape matrices $\matr{X}$, $\matr{Y}$ and $\matr{Z}$ as column vectors, and compute Jacobians on them. Once we have computed the column vector corresponding to $\frac{\partial L}{\partial \matr{X}}$, we will reshape it back to a matrix with the same shape as $\matr{X}$.
 
-\begin{align}
+\begin{flalign}
 \frac{\partial \matr{Z}}{\partial \matr{X}} &=
 \begin{bmatrix}
 \frac{\partial z_{1,1}}{\partial x_{1,1}} & \frac{\partial z_{1,2}}{\partial x_{1,1}} & \frac{\partial z_{2,1}}{\partial x_{1,1}} & \frac{\partial z_{2,2}}{\partial x_{1,1}} \\[0.5em]
@@ -212,8 +264,10 @@ To compute $\frac{\partial L}{\partial \matr{X}}$, we need to compute $\frac{\pa
 \frac{\partial z_{1,1}}{\partial x_{2,1}} & \frac{\partial z_{1,2}}{\partial x_{2,1}} & \frac{\partial z_{2,1}}{\partial x_{2,1}} & \frac{\partial z_{2,2}}{\partial x_{2,1}} \\[0.5em]
 \frac{\partial z_{1,1}}{\partial x_{2,2}} & \frac{\partial z_{1,2}}{\partial x_{2,2}} & \frac{\partial z_{2,1}}{\partial x_{2,2}} & \frac{\partial z_{2,2}}{\partial x_{2,2}} \\[0.5em]
 \frac{\partial z_{1,1}}{\partial x_{2,3}} & \frac{\partial z_{1,2}}{\partial x_{2,3}} & \frac{\partial z_{2,1}}{\partial x_{2,3}} & \frac{\partial z_{2,2}}{\partial x_{2,3}} \\[0.5em]
-\end{bmatrix} \nonumber
-\\ \label{dZbydX}
+\end{bmatrix}
+& \eqncomment{$\matr{X}$, $\matr{Z}$ are being treated as column vectors. Therefore, $\frac{\partial \matr{Z}}{\partial \matr{X}}$ is of shape $6\times4$.}
+\nonumber \\
+\label{dZbydX}
 &=
 \begin{bmatrix}
 y_{1,1} & y_{1,2} & 0 & 0 \\[0.5em]
@@ -223,24 +277,28 @@ y_{3,1} & y_{3,2} & 0 & 0 \\[0.5em]
 0 & 0 & y_{2,1} & y_{2,2} \\[0.5em]
 0 & 0 & y_{3,1} & y_{3,2} \\[0.5em]
 \end{bmatrix}
-\end{align}
+\end{flalign}
 
-Now, $\frac{\partial L}{\partial \matr{Z}}$ expressed as a column vector will be:
+\noindent Now, $\frac{\partial L}{\partial \matr{Z}}$ expressed as a column vector will be:
 
-\begin{equation} \label{dZAsColumnVector}
-\frac{\partial L}{\partial \matr{Z}} =
+\begin{flalign}
+\label{dZAsColumnVector}
+\frac{\partial L}{\partial \matr{Z}} &=
 \begin{bmatrix}
 \frac{\partial L}{\partial z_{1,1}} \\[0.7em]
 \frac{\partial L}{\partial z_{1,2}} \\[0.7em]
 \frac{\partial L}{\partial z_{2,1}} \\[0.7em]
 \frac{\partial L}{\partial z_{2,2}} \\[0.7em]
-\end{bmatrix}
-\end{equation}
+\end{bmatrix} & \eqncomment{Reshaping $\frac{\partial L}{\partial \matr{Z}}$ from shape $2 \times 2$ to $4 \times 1$}
+\end{flalign}
 
-Plugging equations \ref{dZbydX} and \ref{dZAsColumnVector} into equation \ref{dX}, we get:
+\noindent Plugging equations \ref{dZbydX} and \ref{dZAsColumnVector} into equation \ref{dX}, we get:
 
-\begin{align}
+\begin{flalign}
 \frac{\partial L}{\partial \matr{X}} &=
+\frac{\partial \matr{Z}}{\partial \matr{X}}\frac{\partial L}{\partial \matr{Z}} &
+\nonumber \\
+&=
 \begin{bmatrix}
 y_{1,1} & y_{1,2} & 0 & 0 \\[0.5em]
 y_{2,1} & y_{2,2} & 0 & 0 \\[0.5em]
@@ -255,6 +313,7 @@ y_{3,1} & y_{3,2} & 0 & 0 \\[0.5em]
 \frac{\partial L}{\partial z_{2,1}} \\[0.7em]
 \frac{\partial L}{\partial z_{2,2}} \\[0.7em]
 \end{bmatrix}
+& \eqncomment{$\matr{X}$, $\matr{Z}$ and $\frac{\partial L}{\partial \matr{Z}}$ are being treated as column vectors}
 \nonumber \\ 
 &= 
 \begin{bmatrix}
@@ -265,10 +324,10 @@ y_{1,1}.\frac{\partial L}{\partial z_{2,1}} + y_{1,2}.\frac{\partial L}{\partial
 y_{2,1}.\frac{\partial L}{\partial z_{2,1}} + y_{2,2}.\frac{\partial L}{\partial z_{2,2}} \\[0.7em]
 y_{3,1}.\frac{\partial L}{\partial z_{2,1}} + y_{3,2}.\frac{\partial L}{\partial z_{2,2}} \\[0.7em]
 \end{bmatrix} \label{dXAsColumnVector}
-\end{align}
+\end{flalign}
 
-Reshaping column vector in equation \ref{dXAsColumnVector} as a matrix of shape $\matr{X}$, we get:
-\begin{align}
+\noindent Reshaping column vector in equation \ref{dXAsColumnVector} as a matrix of shape $\matr{X}$, we get:
+\begin{flalign}
 \frac{\partial L}{\partial \matr{X}} &=
 \begin{bmatrix}
 y_{1,1}.\frac{\partial L}{\partial z_{1,1}} + y_{1,2}.\frac{\partial L}{\partial z_{1,2}} &
@@ -288,25 +347,28 @@ y_{3,1}.\frac{\partial L}{\partial z_{2,1}} + y_{3,2}.\frac{\partial L}{\partial
 y_{1,1} & y_{2,1} & y_{3,1} \\%[0.5em]
 y_{1,2} & y_{2,2} & y_{3,2} \\%[0.5em]
 \end{bmatrix}
+& \eqncomment{Decomposing into a matmul operation}
 \nonumber \\
 &=
+\underbrace{
 \begin{bmatrix}
 \frac{\partial L}{\partial z_{1,1}} & \frac{\partial L}{\partial z_{1,2}} \\[0.7em]
 \frac{\partial L}{\partial z_{2,1}} & \frac{\partial L}{\partial z_{2,2}} \\[0.7em]
-\end{bmatrix}
+\end{bmatrix}}_{\frac{\partial L}{\partial \matr{Z}}}
+\underbrace{
 \transpose{\begin{bmatrix}
 y_{1,1} & y_{1,2} \\%[0.5em]
 y_{2,1} & y_{2,2} \\%[0.5em]
 y_{3,1} & y_{3,2} \\%[0.5em]
-\end{bmatrix}}
+\end{bmatrix}}}_{\transpose{\matr{Y}}}
 \nonumber \\ \label{dXFinal}
 &= \frac{\partial L}{\partial \matr{Z}} \transpose{\matr{Y}}
-\end{align}
+\end{flalign}
 
 \subsubsection{Computing $\frac{\partial L}{\partial \matr{Y}}$}
 To compute $\frac{\partial L}{\partial \matr{Y}}$, we need to compute $\frac{\partial \matr{Z}}{\partial \matr{Y}}$. To make it easy for us to think about and capture the Jacobian in a two dimensional matrix (as opposed to a tensor), we will reshape matrices $\matr{X}$, $\matr{Y}$ and $\matr{Z}$ as column vectors, and compute Jacobians on them. Once we have computed the column vector corresponding to $\frac{\partial L}{\partial \matr{Y}}$, we will reshape it back to a matrix with the same shape as $\matr{Y}$.
 
-\begin{align}
+\begin{flalign}
 \frac{\partial \matr{Z}}{\partial \matr{Y}} &=
 \begin{bmatrix}
 \frac{\partial z_{1,1}}{\partial y_{1,1}} & \frac{\partial z_{1,2}}{\partial y_{1,1}} & \frac{\partial z_{2,1}}{\partial y_{1,1}} & \frac{\partial z_{2,2}}{\partial y_{1,1}} \\[0.5em]
@@ -315,7 +377,9 @@ To compute $\frac{\partial L}{\partial \matr{Y}}$, we need to compute $\frac{\pa
 \frac{\partial z_{1,1}}{\partial y_{2,2}} & \frac{\partial z_{1,2}}{\partial y_{2,2}} & \frac{\partial z_{2,1}}{\partial y_{2,2}} & \frac{\partial z_{2,2}}{\partial y_{2,2}} \\[0.5em]
 \frac{\partial z_{1,1}}{\partial y_{3,1}} & \frac{\partial z_{1,2}}{\partial y_{3,1}} & \frac{\partial z_{2,1}}{\partial y_{3,1}} & \frac{\partial z_{2,2}}{\partial y_{3,1}} \\[0.5em]
 \frac{\partial z_{1,1}}{\partial y_{3,2}} & \frac{\partial z_{1,2}}{\partial y_{3,2}} & \frac{\partial z_{2,1}}{\partial y_{3,2}} & \frac{\partial z_{2,2}}{\partial y_{3,2}} \\[0.5em]
-\end{bmatrix} \nonumber
+\end{bmatrix}
+& \eqncomment{$\matr{Y}$, $\matr{Z}$ are being treated as column vectors. Therefore, $\frac{\partial \matr{Z}}{\partial \matr{Y}}$ is of shape $6\times4$.}
+\nonumber
 \\
 &=
 \begin{bmatrix}
@@ -326,11 +390,11 @@ x_{1,2} & 0 & x_{2,2} & 0 \\[0.5em]
 x_{1,3} & 0 & x_{2,3} & 0 \\[0.5em]
 0 & x_{1,3} & 0 & x_{2,3} \\[0.5em]
 \end{bmatrix} \label{dZbydY}
-\end{align}
+\end{flalign}
 
-Plugging equations \ref{dZbydY} and \ref{dZAsColumnVector} into equation \ref{dY}, we get:
+\noindent Plugging equations \ref{dZbydY} and \ref{dZAsColumnVector} into equation \ref{dY}, we get:
 
-\begin{align}
+\begin{flalign}
 \frac{\partial L}{\partial \matr{Y}} &=
 \begin{bmatrix}
 x_{1,1} & 0 & x_{2,1} & 0 \\[0.5em]
@@ -346,6 +410,7 @@ x_{1,3} & 0 & x_{2,3} & 0 \\[0.5em]
 \frac{\partial L}{\partial z_{2,1}} \\[0.7em]
 \frac{\partial L}{\partial z_{2,2}} \\[0.7em]
 \end{bmatrix}
+& \eqncomment{$\matr{Y}$, $\matr{Z}$ and $\frac{\partial L}{\partial \matr{Z}}$ are being treated as column vectors}
 \nonumber \\
 &=
 \begin{bmatrix}
@@ -356,11 +421,11 @@ x_{1,2}.\frac{\partial L}{\partial z_{1,2}} + x_{2,2}.\frac{\partial L}{\partial
 x_{1,3}.\frac{\partial L}{\partial z_{1,1}} + x_{2,3}.\frac{\partial L}{\partial z_{2,1}} \\[0.7em]
 x_{1,3}.\frac{\partial L}{\partial z_{1,2}} + x_{2,3}.\frac{\partial L}{\partial z_{2,2}} \\[0.7em]
 \end{bmatrix} \label{dYAsColumnVector}
-\end{align}
+\end{flalign}
 
-Reshaping column vector in equation \ref{dYAsColumnVector} as a matrix of shape $\matr{Y}$, we get:
+\noindent Reshaping column vector in equation \ref{dYAsColumnVector} as a matrix of shape $\matr{Y}$, we get:
 
-\begin{align}
+\begin{flalign}
 \frac{\partial L}{\partial \matr{Y}} &=
 \begin{bmatrix}
 x_{1,1}.\frac{\partial L}{\partial z_{1,1}} + x_{2,1}.\frac{\partial L}{\partial z_{2,1}} &
@@ -381,43 +446,46 @@ x_{1,3} & x_{2,3} \\%[0.5em]
 \frac{\partial L}{\partial z_{1,1}} & \frac{\partial L}{\partial z_{1,2}} \\[0.7em]
 \frac{\partial L}{\partial z_{2,1}} & \frac{\partial L}{\partial z_{2,2}} \\[0.7em]
 \end{bmatrix}
+& \eqncomment{Decomposing into a matmul operation}
 \nonumber \\
 &=
+\underbrace{
 \transpose{
 \begin{bmatrix}
 x_{1,1} & x_{1,2} & x_{1,3} \\%[0.5em]
 x_{2,1} & x_{2,2} & x_{2,3} \\%[0.5em]
-\end{bmatrix}}
+\end{bmatrix}}}_{\transpose{\matr{X}}}
+\underbrace{
 \begin{bmatrix}
 \frac{\partial L}{\partial z_{1,1}} & \frac{\partial L}{\partial z_{1,2}} \\[0.7em]
 \frac{\partial L}{\partial z_{2,1}} & \frac{\partial L}{\partial z_{2,2}} \\[0.7em]
-\end{bmatrix}
+\end{bmatrix}}_{\frac{\partial L}{\partial \matr{Z}}}
 \nonumber \\
 &= \transpose{\matr{X}} \frac{\partial L}{\partial \matr{Z}}
-\end{align}
+\end{flalign}
 
 \section{Element-wise operation on a Matrix}
 \subsection{Forward Pass}
 Consider some function $g(x)$ which is applied element-wise on a matrix $\matr{X}$ of shape $3 \times 2$. Let $\matr{Z} = g(\matr{X})$. $\matr{Z}$ will be of shape $3 \times 2$.
 
-\begin{displaymath}
-\matr{X} =
+\begin{flalign}
+\matr{X} &=
 \begin{bmatrix}
 x_{1,1} & x_{1,2} \\%[0.5em]
 x_{2,1} & x_{2,2} \\%[0.5em]
 x_{3,1} & x_{3,2} \\%[0.5em]
-\end{bmatrix}
-\end{displaymath}
+\end{bmatrix} &
+\end{flalign}
 
-$\matr{Z}$ can be expressed as:
+\noindent $\matr{Z}$ can be expressed as:
 
-\begin{align}
+\begin{flalign}
 \matr{Z} &=
 \begin{bmatrix}
 z_{1,1} & z_{1,2} \\%[0.5em]
 z_{2,1} & z_{2,2} \\%[0.5em]
 z_{3,1} & z_{3,2} \\%[0.5em]
-\end{bmatrix}
+\end{bmatrix} &
 \nonumber \\
 &=
 \begin{bmatrix}
@@ -425,30 +493,30 @@ g(x_{1,1}) & g(x_{1,2}) \\[0.5em]
 g(x_{2,1}) & g(x_{2,2}) \\[0.5em]
 g(x_{3,1}) & g(x_{3,2}) \\[0.5em]
 \end{bmatrix}
-\end{align}
+\end{flalign}
 
 \subsection{Backward Pass}
 We have $\frac{\partial L}{\partial \matr{Z}}$ of shape $3 \times 2$.
 
-\begin{displaymath}
-\frac{\partial L}{\partial \matr{Z}} =
+\begin{flalign}
+\frac{\partial L}{\partial \matr{Z}} &=
 \begin{bmatrix}
 \frac{\partial L}{\partial z_{1,1}} & \frac{\partial L}{\partial z_{1,2}} \\[0.5em]
 \frac{\partial L}{\partial z_{2,1}} & \frac{\partial L}{\partial z_{2,2}} \\[0.5em]
 \frac{\partial L}{\partial z_{3,1}} & \frac{\partial L}{\partial z_{3,2}} \\[0.5em]
-\end{bmatrix}
-\end{displaymath}
+\end{bmatrix} & \eqncomment{$\frac{\partial L}{\partial \matr{Z}}$ is the same shape as $\matr{Z}$ as $L$ is a scalar}
+\end{flalign}
 
-We now need to compute $\frac{\partial L}{\partial \matr{X}}$. Using chain rule, we get:
+\noindent We now need to compute $\frac{\partial L}{\partial \matr{X}}$. Using chain rule, we get:
 
-\begin{equation} \label{dX_elewise_single_matrix}
-\frac{\partial L}{\partial \matr{X}} = \frac{\partial \matr{Z}}{\partial \matr{X}}\frac{\partial L}{\partial \matr{Z}}
-\end{equation}
+\begin{flalign} \label{dX_elewise_single_matrix}
+\frac{\partial L}{\partial \matr{X}} &= \frac{\partial \matr{Z}}{\partial \matr{X}}\frac{\partial L}{\partial \matr{Z}} &
+\end{flalign}
 
 \subsubsection{Computing $\frac{\partial L}{\partial \matr{X}}$}
 To compute $\frac{\partial L}{\partial \matr{X}}$, we need to compute $\frac{\partial \matr{Z}}{\partial \matr{X}}$. To make it easy for us to think about and capture the Jacobian in a two dimensional matrix (as opposed to a tensor), we will reshape matrices $\matr{X}$ and $\matr{Z}$ as column vectors, and compute Jacobians on them. Once we have computed the column vector corresponding to $\frac{\partial L}{\partial \matr{X}}$, we will reshape it back to a matrix with the same shape as $\matr{X}$.
 
-\begin{align}
+\begin{flalign}
 \frac{\partial \matr{Z}}{\partial \matr{X}} &=
 \begin{bmatrix}
 \frac{\partial z_{1,1}}{\partial x_{1,1}} & \frac{\partial z_{1,2}}{\partial x_{1,1}} & \frac{\partial z_{2,1}}{\partial x_{1,1}} & \frac{\partial z_{2,2}}{\partial x_{1,1}} & \frac{\partial z_{3,1}}{\partial x_{1,1}} & \frac{\partial z_{3,2}}{\partial x_{1,1}}\\[0.7em]
@@ -457,8 +525,43 @@ To compute $\frac{\partial L}{\partial \matr{X}}$, we need to compute $\frac{\pa
 \frac{\partial z_{1,1}}{\partial x_{2,2}} & \frac{\partial z_{1,2}}{\partial x_{2,2}} & \frac{\partial z_{2,1}}{\partial x_{2,2}} & \frac{\partial z_{2,2}}{\partial x_{2,2}} & \frac{\partial z_{3,1}}{\partial x_{2,2}} & \frac{\partial z_{3,2}}{\partial x_{2,2}}\\[0.7em]
 \frac{\partial z_{1,1}}{\partial x_{3,1}} & \frac{\partial z_{1,2}}{\partial x_{3,1}} & \frac{\partial z_{2,1}}{\partial x_{3,1}} & \frac{\partial z_{2,2}}{\partial x_{3,1}} & \frac{\partial z_{3,1}}{\partial x_{3,1}} & \frac{\partial z_{3,2}}{\partial x_{3,1}}\\[0.7em]
 \frac{\partial z_{1,1}}{\partial x_{3,2}} & \frac{\partial z_{1,2}}{\partial x_{3,2}} & \frac{\partial z_{2,1}}{\partial x_{3,2}} & \frac{\partial z_{2,2}}{\partial x_{3,2}} & \frac{\partial z_{3,1}}{\partial x_{3,2}} & \frac{\partial z_{3,2}}{\partial x_{3,2}}\\[0.7em]
-\end{bmatrix} \nonumber
+\end{bmatrix}
+& \longeqncomment{$\matr{X}$, $\matr{Z}$ are being treated as column vectors.}{Therefore, $\frac{\partial \matr{Z}}{\partial \matr{X}}$ is of shape $6\times6$.}
+\nonumber
 \\ \label{dZbydX_elewise_single_matrix}
+&=
+\begin{bmatrix*}[c]
+g'(x_{1,1}) & 0 & 0 & 0 & 0 & 0 \\[0.0em]
+0 & g'(x_{1,2}) & 0 & 0 & 0 & 0 \\[0.0em]
+0 & 0 & g'(x_{2,1}) & 0 & 0 & 0 \\[0.0em]
+0 & 0 & 0 & g'(x_{2,2}) & 0 & 0 \\[0.0em]
+0 & 0 & 0 & 0 & g'(x_{3,1}) & 0 \\[0.0em]
+0 & 0 & 0 & 0 & 0 & g'(x_{3,2}) \\[0.0em]
+\end{bmatrix*}
+\end{flalign}
+
+\noindent Now, $\frac{\partial L}{\partial \matr{Z}}$ expressed as a column vector will be:
+
+\begin{flalign} \label{dZAsColumnVector_elewise_single_matrix}
+\frac{\partial L}{\partial \matr{Z}} &=
+\begin{bmatrix}
+\frac{\partial L}{\partial z_{1,1}} \\[0.7em]
+\frac{\partial L}{\partial z_{1,2}} \\[0.7em]
+\frac{\partial L}{\partial z_{2,1}} \\[0.7em]
+\frac{\partial L}{\partial z_{2,2}} \\[0.7em]
+\frac{\partial L}{\partial z_{3,1}} \\[0.7em]
+\frac{\partial L}{\partial z_{3,2}} \\[0.7em]
+\end{bmatrix}
+& \eqncomment{Reshaping $\frac{\partial L}{\partial \matr{Z}}$ from shape $3 \times 2$ to $6 \times 1$}
+\end{flalign}
+
+
+\noindent Plugging equations \ref{dZbydX_elewise_single_matrix} and \ref{dZAsColumnVector_elewise_single_matrix} into equation \ref{dX_elewise_single_matrix}, we get:
+
+\begin{flalign}
+\frac{\partial L}{\partial \matr{X}} &=
+\frac{\partial \matr{Z}}{\partial \matr{X}}\frac{\partial L}{\partial \matr{Z}} &
+\nonumber \\
 &=
 \begin{bmatrix}
 g'(x_{1,1}) & 0 & 0 & 0 & 0 & 0 \\[0.5em]
@@ -468,12 +571,6 @@ g'(x_{1,1}) & 0 & 0 & 0 & 0 & 0 \\[0.5em]
 0 & 0 & 0 & 0 & g'(x_{3,1}) & 0 \\[0.5em]
 0 & 0 & 0 & 0 & 0 & g'(x_{3,2}) \\[0.5em]
 \end{bmatrix}
-\end{align}
-
-Now, $\frac{\partial L}{\partial \matr{Z}}$ expressed as a column vector will be:
-
-\begin{equation} \label{dZAsColumnVector_elewise_single_matrix}
-\frac{\partial L}{\partial \matr{Z}} =
 \begin{bmatrix}
 \frac{\partial L}{\partial z_{1,1}} \\[0.7em]
 \frac{\partial L}{\partial z_{1,2}} \\[0.7em]
@@ -482,29 +579,7 @@ Now, $\frac{\partial L}{\partial \matr{Z}}$ expressed as a column vector will be
 \frac{\partial L}{\partial z_{3,1}} \\[0.7em]
 \frac{\partial L}{\partial z_{3,2}} \\[0.7em]
 \end{bmatrix}
-\end{equation}
-
-
-Plugging equations \ref{dZbydX_elewise_single_matrix} and \ref{dZAsColumnVector_elewise_single_matrix} into equation \ref{dX_elewise_single_matrix}, we get:
-
-\begin{align}
-\frac{\partial L}{\partial \matr{X}} &=
-\begin{bmatrix}
-g'(x_{1,1}) & 0 & 0 & 0 & 0 & 0 \\[0.5em]
-0 & g'(x_{1,2}) & 0 & 0 & 0 & 0 \\[0.5em]
-0 & 0 & g'(x_{2,1}) & 0 & 0 & 0 \\[0.5em]
-0 & 0 & 0 & g'(x_{2,2}) & 0 & 0 \\[0.5em]
-0 & 0 & 0 & 0 & g'(x_{3,1}) & 0 \\[0.5em]
-0 & 0 & 0 & 0 & 0 & g'(x_{3,2}) \\[0.5em]
-\end{bmatrix}
-\begin{bmatrix}
-\frac{\partial L}{\partial z_{1,1}} \\[0.7em]
-\frac{\partial L}{\partial z_{1,2}} \\[0.7em]
-\frac{\partial L}{\partial z_{2,1}} \\[0.7em]
-\frac{\partial L}{\partial z_{2,2}} \\[0.7em]
-\frac{\partial L}{\partial z_{3,1}} \\[0.7em]
-\frac{\partial L}{\partial z_{3,2}} \\[0.7em]
-\end{bmatrix}
+& \longeqncomment{$\matr{X}$, $\matr{Z}$ and $\frac{\partial L}{\partial \matr{Z}}$ are being}{treated as column vectors.}
 \nonumber \\
 &=
 \begin{bmatrix}
@@ -515,22 +590,22 @@ g'(x_{2,2}).\frac{\partial L}{\partial z_{2,2}} \\[0.7em]
 g'(x_{3,1}).\frac{\partial L}{\partial z_{3,1}} \\[0.7em]
 g'(x_{3,2}).\frac{\partial L}{\partial z_{3,2}} \\[0.7em]
 \end{bmatrix} \label{dXAsColumnVector_elewise_single_matrix}
-\end{align}
+\end{flalign}
 
-Note, we will be using $\circ$ to denote Hadamard product. Also $g'(\matr{X})$ like $g(\matr{X})$ will be applied element-wise.
+\noindent Note, we will be using $\circ$ to denote element-wise multiplication between matrices popularly known as Hadamard product. Also $g'(\matr{X})$ like $g(\matr{X})$ will be applied element-wise.
 
-\begin{align}
+\begin{flalign}
 g'(\matr{X}) &=
 \begin{bmatrix}
 g'(x_{1,1}) & g'(x_{1,2}) \\[0.5em]
 g'(x_{2,1}) & g'(x_{2,2}) \\[0.5em]
 g'(x_{3,1}) & g'(x_{3,2}) \\[0.5em]
-\end{bmatrix} \nonumber
-\end{align}
+\end{bmatrix} & \nonumber
+\end{flalign}
 
-Now, reshaping column vector in equation \ref{dXAsColumnVector_elewise_single_matrix} as a matrix of shape $\matr{X}$, we get:
+\noindent Now, reshaping column vector in equation \ref{dXAsColumnVector_elewise_single_matrix} as a matrix of shape $\matr{X}$, we get:
 
-\begin{align}
+\begin{flalign}
 \frac{\partial L}{\partial \matr{X}} &=
 \begin{bmatrix}
 g'(x_{1,1}).\frac{\partial L}{\partial z_{1,1}} &
@@ -542,52 +617,56 @@ g'(x_{3,2}).\frac{\partial L}{\partial z_{3,2}} \\[0.7em]
 \end{bmatrix}
 \nonumber \\
 &=
+\underbrace{
 \begin{bmatrix}
 g'(x_{1,1}) & g'(x_{1,2}) \\[0.5em]
 g'(x_{2,1}) & g'(x_{2,2}) \\[0.5em]
 g'(x_{3,1}) & g'(x_{3,2}) \\[0.5em]
-\end{bmatrix}
+\end{bmatrix}}_{g'(\matr{X})}
 \circ
+\underbrace{
 \begin{bmatrix}
 \frac{\partial L}{\partial z_{1,1}} & \frac{\partial L}{\partial z_{1,2}} \\[0.5em]
 \frac{\partial L}{\partial z_{2,1}} & \frac{\partial L}{\partial z_{2,2}} \\[0.5em]
 \frac{\partial L}{\partial z_{3,1}} & \frac{\partial L}{\partial z_{3,2}} \\[0.5em]
-\end{bmatrix}
+\end{bmatrix}}_{\frac{\partial L}{\partial \matr{Z}}}
+& \eqncomment{Decomposing into an element-wise multiplication between matrices.}
 \nonumber \\
 &=
 g'(\matr{X}) \circ \frac{\partial L}{\partial \matr{Z}}
-\end{align}
+\end{flalign}
 
 \section{Hadamard product}
 \subsection{Forward Pass}
-Let $\matr{X}$ be a $3 \times 2$ matrix, and let $\matr{Y}$ be a $3 \times 2$ matrix. Let $\matr{Z} = \matr{X} \circ \matr{Y}$ that is element-wise multiplication between $\matr{X}$ and $\matr{Y}$. $\matr{Z}$ will be of shape $3 \times 2$.
+Let $\matr{X}$ be a $3 \times 2$ matrix, and let $\matr{Y}$ be a $3 \times 2$ matrix. Let $\matr{Z} = \matr{X} \circ \matr{Y}$ that is element-wise multiplication between $\matr{X}$ and $\matr{Y}$.
 
-\begin{displaymath}
-\matr{X} =
+\begin{flalign}
+\matr{X} &=
 \begin{bmatrix}
 x_{1,1} & x_{1,2} \\%[0.5em]
 x_{2,1} & x_{2,2} \\%[0.5em]
 x_{3,1} & x_{3,2} \\%[0.5em]
-\end{bmatrix}
-\end{displaymath}
+\end{bmatrix} &
+\end{flalign}
 
-\begin{displaymath}
-\matr{Y} =
+\begin{flalign}
+\matr{Y} &=
 \begin{bmatrix}
 y_{1,1} & y_{1,2} \\%[0.5em]
 y_{2,1} & y_{2,2} \\%[0.5em]
 y_{3,1} & y_{3,2} \\%[0.5em]
-\end{bmatrix}
-\end{displaymath}
+\end{bmatrix} &
+\end{flalign}
 
-Given $\matr{Z} = \matr{X} \circ \matr{Y}$, Z is a $3 \times 2$ matrix which can be expressed as:
+\noindent Given $\matr{Z} = \matr{X} \circ \matr{Y}$, $\matr{Z}$ is a $3 \times 2$ matrix which can be expressed as:
 
-\begin{align}
+\begin{flalign}
 \matr{Z} &= \begin{bmatrix}
 z_{1,1} & z_{1,2}\\[0.5em]
 z_{2,1} & z_{2,2}\\[0.5em]
 z_{3,1} & z_{3,2}\\[0.5em]
 \end{bmatrix}
+&
 \\
 &=
 \begin{bmatrix}
@@ -595,34 +674,35 @@ x_{1,1}.y_{1,1} & x_{1,2}.y_{1,2} \\[0.5em]
 x_{2,1}.y_{2,1} & x_{2,2}.y_{2,2} \\[0.5em]
 x_{3,1}.y_{3,1} & x_{3,2}.y_{3,2} \\[0.5em]
 \end{bmatrix}
-\end{align}
+\end{flalign}
 
 \subsection{Backward Pass}
 We have $\frac{\partial L}{\partial \matr{Z}}$ of shape $3 \times 2$.
 
-\begin{displaymath}
-\frac{\partial L}{\partial \matr{Z}} =
+\begin{flalign}
+\frac{\partial L}{\partial \matr{Z}} &=
 \begin{bmatrix}
 \frac{\partial L}{\partial z_{1,1}} & \frac{\partial L}{\partial z_{1,2}} \\[0.5em]
 \frac{\partial L}{\partial z_{2,1}} & \frac{\partial L}{\partial z_{2,2}} \\[0.5em]
 \frac{\partial L}{\partial z_{3,1}} & \frac{\partial L}{\partial z_{3,2}} \\[0.5em]
 \end{bmatrix}
-\end{displaymath}
+& \eqncomment{$\frac{\partial L}{\partial \matr{Z}}$ is the same shape as $\matr{Z}$ as $L$ is a scalar}
+\end{flalign}
 
-We now need to compute $\frac{\partial L}{\partial \matr{X}}$ and $\frac{\partial L}{\partial \matr{Y}}$. Using chain rule, we get:
+\noindent We now need to compute $\frac{\partial L}{\partial \matr{X}}$ and $\frac{\partial L}{\partial \matr{Y}}$. Using chain rule, we get:
 
-\begin{equation} \label{dX_hadamard_product}
-\frac{\partial L}{\partial \matr{X}} = \frac{\partial \matr{Z}}{\partial \matr{X}}\frac{\partial L}{\partial \matr{Z}}
-\end{equation}
+\begin{flalign} \label{dX_hadamard_product}
+\frac{\partial L}{\partial \matr{X}} &= \frac{\partial \matr{Z}}{\partial \matr{X}}\frac{\partial L}{\partial \matr{Z}} &
+\end{flalign}
 
-\begin{equation} \label{dY_hadamard_product}
-\frac{\partial L}{\partial \matr{Y}} = \frac{\partial \matr{Z}}{\partial \matr{Y}}\frac{\partial L}{\partial \matr{Z}}
-\end{equation}
+\begin{flalign} \label{dY_hadamard_product}
+\frac{\partial L}{\partial \matr{Y}} &= \frac{\partial \matr{Z}}{\partial \matr{Y}}\frac{\partial L}{\partial \matr{Z}} &
+\end{flalign}
 
 \subsubsection{Computing $\frac{\partial L}{\partial \matr{X}}$}
 To compute $\frac{\partial L}{\partial \matr{X}}$, we need to compute $\frac{\partial \matr{Z}}{\partial \matr{X}}$. To make it easy for us to think about and capture the Jacobian in a two dimensional matrix (as opposed to a tensor), we will reshape matrices $\matr{X}$, $\matr{Y}$ and $\matr{Z}$ as column vectors, and compute Jacobians on them. Once we have computed the column vector corresponding to $\frac{\partial L}{\partial \matr{X}}$, we will reshape it back to a matrix with the same shape as $\matr{X}$.
 
-\begin{align}
+\begin{flalign}
 \frac{\partial \matr{Z}}{\partial \matr{X}} &=
 \begin{bmatrix}
 \frac{\partial z_{1,1}}{\partial x_{1,1}} & \frac{\partial z_{1,2}}{\partial x_{1,1}} & \frac{\partial z_{2,1}}{\partial x_{1,1}} & \frac{\partial z_{2,2}}{\partial x_{1,1}} & \frac{\partial z_{3,1}}{\partial x_{1,1}} & \frac{\partial z_{3,2}}{\partial x_{1,1}}\\[0.7em]
@@ -631,7 +711,9 @@ To compute $\frac{\partial L}{\partial \matr{X}}$, we need to compute $\frac{\pa
 \frac{\partial z_{1,1}}{\partial x_{2,2}} & \frac{\partial z_{1,2}}{\partial x_{2,2}} & \frac{\partial z_{2,1}}{\partial x_{2,2}} & \frac{\partial z_{2,2}}{\partial x_{2,2}} & \frac{\partial z_{3,1}}{\partial x_{2,2}} & \frac{\partial z_{3,2}}{\partial x_{2,2}}\\[0.7em]
 \frac{\partial z_{1,1}}{\partial x_{3,1}} & \frac{\partial z_{1,2}}{\partial x_{3,1}} & \frac{\partial z_{2,1}}{\partial x_{3,1}} & \frac{\partial z_{2,2}}{\partial x_{3,1}} & \frac{\partial z_{3,1}}{\partial x_{3,1}} & \frac{\partial z_{3,2}}{\partial x_{3,1}}\\[0.7em]
 \frac{\partial z_{1,1}}{\partial x_{3,2}} & \frac{\partial z_{1,2}}{\partial x_{3,2}} & \frac{\partial z_{2,1}}{\partial x_{3,2}} & \frac{\partial z_{2,2}}{\partial x_{3,2}} & \frac{\partial z_{3,1}}{\partial x_{3,2}} & \frac{\partial z_{3,2}}{\partial x_{3,2}}\\[0.7em]
-\end{bmatrix} \nonumber
+\end{bmatrix}
+& \longeqncomment{$\matr{X}$, $\matr{Z}$ are being treated as column vectors.}{Therefore, $\frac{\partial \matr{Z}}{\partial \matr{X}}$ is of shape $6\times6$.}
+\nonumber
 \\ \label{dZbydX_hadamard_product}
 &=
 \begin{bmatrix}
@@ -642,12 +724,12 @@ y_{1,1} & 0 & 0 & 0 & 0 & 0 \\[0.5em]
 0 & 0 & 0 & 0 & y_{3,1} & 0 \\[0.5em]
 0 & 0 & 0 & 0 & 0 & y_{3,2} \\[0.5em]
 \end{bmatrix}
-\end{align}
+\end{flalign}
 
-Now, $\frac{\partial L}{\partial \matr{Z}}$ expressed as a column vector will be:
+\noindent Now, $\frac{\partial L}{\partial \matr{Z}}$ expressed as a column vector will be:
 
-\begin{equation} \label{dZAsColumnVector_hadamard_product_Y}
-\frac{\partial L}{\partial \matr{Z}} =
+\begin{flalign} \label{dZAsColumnVector_hadamard_product}
+\frac{\partial L}{\partial \matr{Z}} &=
 \begin{bmatrix}
 \frac{\partial L}{\partial z_{1,1}} \\[0.7em]
 \frac{\partial L}{\partial z_{1,2}} \\[0.7em]
@@ -656,12 +738,16 @@ Now, $\frac{\partial L}{\partial \matr{Z}}$ expressed as a column vector will be
 \frac{\partial L}{\partial z_{3,1}} \\[0.7em]
 \frac{\partial L}{\partial z_{3,2}} \\[0.7em]
 \end{bmatrix}
-\end{equation}
+& \eqncomment{Reshaping $\frac{\partial L}{\partial \matr{Z}}$ from shape $3 \times 2$ to $6 \times 1$}
+\end{flalign}
 
-Plugging equations \ref{dZbydX_hadamard_product} and \ref{dZAsColumnVector_hadamard_product_Y} into equation \ref{dX_hadamard_product}, we get:
+\noindent Plugging equations \ref{dZbydX_hadamard_product} and \ref{dZAsColumnVector_hadamard_product} into equation \ref{dX_hadamard_product}, we get:
 
-\begin{align}
+\begin{flalign}
 \frac{\partial L}{\partial \matr{X}} &=
+\frac{\partial \matr{Z}}{\partial \matr{X}}\frac{\partial L}{\partial \matr{Z}} &
+\nonumber \\
+&=
 \begin{bmatrix}
 y_{1,1} & 0 & 0 & 0 & 0 & 0 \\[0.5em]
 0 & y_{1,2} & 0 & 0 & 0 & 0 \\[0.5em]
@@ -678,6 +764,7 @@ y_{1,1} & 0 & 0 & 0 & 0 & 0 \\[0.5em]
 \frac{\partial L}{\partial z_{3,1}} \\[0.7em]
 \frac{\partial L}{\partial z_{3,2}} \\[0.7em]
 \end{bmatrix}
+& \eqncomment{$\matr{X}$, $\matr{Z}$ and $\frac{\partial L}{\partial \matr{Z}}$ are being treated as column vectors}
 \nonumber \\
 &=
 \begin{bmatrix}
@@ -688,11 +775,11 @@ y_{2,2}.\frac{\partial L}{\partial z_{2,2}} \\[0.7em]
 y_{3,1}.\frac{\partial L}{\partial z_{3,1}} \\[0.7em]
 y_{3,2}.\frac{\partial L}{\partial z_{3,2}} \\[0.7em]
 \end{bmatrix} \label{dXAsColumnVector_hadamard_product}
-\end{align}
+\end{flalign}
 
-Now, reshaping column vector in equation \ref{dXAsColumnVector_hadamard_product} as a matrix of shape $\matr{X}$, we get:
+\noindent Reshaping column vector in equation \ref{dXAsColumnVector_hadamard_product} as a matrix of shape $\matr{X}$, we get:
 
-\begin{align}
+\begin{flalign}
 \frac{\partial L}{\partial \matr{X}} &=
 \begin{bmatrix}
 y_{1,1}.\frac{\partial L}{\partial z_{1,1}} &
@@ -704,27 +791,30 @@ y_{3,2}.\frac{\partial L}{\partial z_{3,2}} \\[0.7em]
 \end{bmatrix}
 \nonumber \\
 &=
+\underbrace{
 \begin{bmatrix}
 y_{1,1} & y_{1,2} \\%[0.5em]
 y_{2,1} & y_{2,2} \\%[0.5em]
 y_{3,1} & y_{3,2} \\%[0.5em]
-\end{bmatrix}
+\end{bmatrix}}_{\matr{Y}}
 \circ
+\underbrace{
 \begin{bmatrix}
 \frac{\partial L}{\partial z_{1,1}} & \frac{\partial L}{\partial z_{1,2}} \\[0.5em]
 \frac{\partial L}{\partial z_{2,1}} & \frac{\partial L}{\partial z_{2,2}} \\[0.5em]
 \frac{\partial L}{\partial z_{3,1}} & \frac{\partial L}{\partial z_{3,2}} \\[0.5em]
-\end{bmatrix}
+\end{bmatrix}}_{\frac{\partial L}{\partial \matr{Z}}}
+& \eqncomment{Decomposing into an element-wise multiplication between matrices.}
 \nonumber \\
 &=
 \matr{Y} \circ \frac{\partial L}{\partial \matr{Z}}
-\end{align}
+\end{flalign}
 
 \subsubsection{Computing $\frac{\partial L}{\partial \matr{Y}}$}
 To compute $\frac{\partial L}{\partial \matr{Y}}$, we need to compute $\frac{\partial \matr{Z}}{\partial \matr{Y}}$. To make it easy for us to think about and capture the Jacobian in a two dimensional matrix (as opposed to a tensor), we will reshape matrices $\matr{X}$, $\matr{Y}$ and $\matr{Z}$ as column vectors, and compute Jacobians on them. Once we have computed the column vector corresponding to $\frac{\partial L}{\partial \matr{Y}}$, we will reshape it back to a matrix with the same shape as $\matr{Y}$.
 
-\begin{align}
-\frac{\partial \matr{Z}}{\partial \matr{X}} &=
+\begin{flalign}
+\frac{\partial \matr{Z}}{\partial \matr{Y}} &=
 \begin{bmatrix}
 \frac{\partial z_{1,1}}{\partial y_{1,1}} & \frac{\partial z_{1,2}}{\partial y_{1,1}} & \frac{\partial z_{2,1}}{\partial y_{1,1}} & \frac{\partial z_{2,2}}{\partial y_{1,1}} & \frac{\partial z_{3,1}}{\partial y_{1,1}} & \frac{\partial z_{3,2}}{\partial y_{1,1}}\\[0.7em]
 \frac{\partial z_{1,1}}{\partial y_{1,2}} & \frac{\partial z_{1,2}}{\partial y_{1,2}} & \frac{\partial z_{2,1}}{\partial y_{1,2}} & \frac{\partial z_{2,2}}{\partial y_{1,2}} & \frac{\partial z_{3,1}}{\partial y_{1,2}} & \frac{\partial z_{3,2}}{\partial y_{1,2}}\\[0.7em]
@@ -732,7 +822,9 @@ To compute $\frac{\partial L}{\partial \matr{Y}}$, we need to compute $\frac{\pa
 \frac{\partial z_{1,1}}{\partial y_{2,2}} & \frac{\partial z_{1,2}}{\partial y_{2,2}} & \frac{\partial z_{2,1}}{\partial y_{2,2}} & \frac{\partial z_{2,2}}{\partial y_{2,2}} & \frac{\partial z_{3,1}}{\partial y_{2,2}} & \frac{\partial z_{3,2}}{\partial y_{2,2}}\\[0.7em]
 \frac{\partial z_{1,1}}{\partial y_{3,1}} & \frac{\partial z_{1,2}}{\partial y_{3,1}} & \frac{\partial z_{2,1}}{\partial y_{3,1}} & \frac{\partial z_{2,2}}{\partial y_{3,1}} & \frac{\partial z_{3,1}}{\partial y_{3,1}} & \frac{\partial z_{3,2}}{\partial y_{3,1}}\\[0.7em]
 \frac{\partial z_{1,1}}{\partial y_{3,2}} & \frac{\partial z_{1,2}}{\partial y_{3,2}} & \frac{\partial z_{2,1}}{\partial y_{3,2}} & \frac{\partial z_{2,2}}{\partial y_{3,2}} & \frac{\partial z_{3,1}}{\partial y_{3,2}} & \frac{\partial z_{3,2}}{\partial y_{3,2}}\\[0.7em]
-\end{bmatrix} \nonumber
+\end{bmatrix}
+& \longeqncomment{$\matr{Y}$, $\matr{Z}$ are being treated as column vectors.}{Therefore, $\frac{\partial \matr{Z}}{\partial \matr{Y}}$ is of shape $6\times6$.}
+\nonumber
 \\ \label{dZbydY_hadamard_product}
 &=
 \begin{bmatrix}
@@ -743,26 +835,15 @@ x_{1,1} & 0 & 0 & 0 & 0 & 0 \\[0.5em]
 0 & 0 & 0 & 0 & x_{3,1} & 0 \\[0.5em]
 0 & 0 & 0 & 0 & 0 & x_{3,2} \\[0.5em]
 \end{bmatrix}
-\end{align}
+\end{flalign}
 
-Now, $\frac{\partial L}{\partial \matr{Z}}$ expressed as a column vector will be:
+\noindent Plugging equations \ref{dZbydY_hadamard_product} and \ref{dZAsColumnVector_hadamard_product} into equation \ref{dY_hadamard_product}, we get:
 
-\begin{equation} \label{dZAsColumnVector_hadamard_product_X}
-\frac{\partial L}{\partial \matr{Z}} =
-\begin{bmatrix}
-\frac{\partial L}{\partial z_{1,1}} \\[0.7em]
-\frac{\partial L}{\partial z_{1,2}} \\[0.7em]
-\frac{\partial L}{\partial z_{2,1}} \\[0.7em]
-\frac{\partial L}{\partial z_{2,2}} \\[0.7em]
-\frac{\partial L}{\partial z_{3,1}} \\[0.7em]
-\frac{\partial L}{\partial z_{3,2}} \\[0.7em]
-\end{bmatrix}
-\end{equation}
-
-Plugging equations \ref{dZbydY_hadamard_product} and \ref{dZAsColumnVector_hadamard_product_X} into equation \ref{dY_hadamard_product}, we get:
-
-\begin{align}
-\frac{\partial L}{\partial \matr{X}} &=
+\begin{flalign}
+\frac{\partial L}{\partial \matr{Y}} &=
+\frac{\partial \matr{Z}}{\partial \matr{Y}}\frac{\partial L}{\partial \matr{Z}} &
+\nonumber \\
+&=
 \begin{bmatrix}
 x_{1,1} & 0 & 0 & 0 & 0 & 0 \\[0.5em]
 0 & x_{1,2} & 0 & 0 & 0 & 0 \\[0.5em]
@@ -779,6 +860,7 @@ x_{1,1} & 0 & 0 & 0 & 0 & 0 \\[0.5em]
 \frac{\partial L}{\partial z_{3,1}} \\[0.7em]
 \frac{\partial L}{\partial z_{3,2}} \\[0.7em]
 \end{bmatrix}
+& \eqncomment{$\matr{Y}$, $\matr{Z}$ and $\frac{\partial L}{\partial \matr{Z}}$ are being treated as column vectors}
 \nonumber \\
 &=
 \begin{bmatrix}
@@ -789,11 +871,11 @@ x_{2,2}.\frac{\partial L}{\partial z_{2,2}} \\[0.7em]
 x_{3,1}.\frac{\partial L}{\partial z_{3,1}} \\[0.7em]
 x_{3,2}.\frac{\partial L}{\partial z_{3,2}} \\[0.7em]
 \end{bmatrix} \label{dYAsColumnVector_hadamard_product}
-\end{align}
+\end{flalign}
 
-Now, reshaping column vector in equation \ref{dYAsColumnVector_hadamard_product} as a matrix of shape $\matr{Y}$, we get:
+\noindent Now, reshaping column vector in equation \ref{dYAsColumnVector_hadamard_product} as a matrix of shape $\matr{Y}$, we get:
 
-\begin{align}
+\begin{flalign}
 \frac{\partial L}{\partial \matr{X}} &=
 \begin{bmatrix}
 x_{1,1}.\frac{\partial L}{\partial z_{1,1}} &
@@ -805,52 +887,56 @@ x_{3,2}.\frac{\partial L}{\partial z_{3,2}} \\[0.7em]
 \end{bmatrix}
 \nonumber \\
 &=
+\underbrace{
 \begin{bmatrix}
 x_{1,1} & x_{1,2} \\%[0.5em]
 x_{2,1} & x_{2,2} \\%[0.5em]
 x_{3,1} & x_{3,2} \\%[0.5em]
-\end{bmatrix}
+\end{bmatrix}}_{\matr{X}}
 \circ
+\underbrace{
 \begin{bmatrix}
 \frac{\partial L}{\partial z_{1,1}} & \frac{\partial L}{\partial z_{1,2}} \\[0.5em]
 \frac{\partial L}{\partial z_{2,1}} & \frac{\partial L}{\partial z_{2,2}} \\[0.5em]
 \frac{\partial L}{\partial z_{3,1}} & \frac{\partial L}{\partial z_{3,2}} \\[0.5em]
-\end{bmatrix}
+\end{bmatrix}}_{\frac{\partial L}{\partial \matr{Z}}}
+& \eqncomment{Decomposing into an element-wise multiplication between matrices.}
 \nonumber \\
 &=
 \matr{X} \circ \frac{\partial L}{\partial \matr{Z}}
-\end{align}
+\end{flalign}
 
 \section{Matrix Addition}
 \subsection{Forward Pass}
-Let $\matr{X}$ be a $3 \times 2$ matrix, and let $\matr{Y}$ be a $3 \times 2$ matrix. Let $\matr{Z} = \matr{X} + \matr{Y}$ that is element-wise addition between $\matr{X}$ and $\matr{Y}$. $\matr{Z}$ will be of shape $3 \times 2$.
+Let $\matr{X}$ be a $3 \times 2$ matrix, and let $\matr{Y}$ be a $3 \times 2$ matrix. Let $\matr{Z} = \matr{X} + \matr{Y}$ that is element-wise addition between $\matr{X}$ and $\matr{Y}$.
 
-\begin{displaymath}
-\matr{X} =
+\begin{flalign}
+\matr{X} &=
 \begin{bmatrix}
 x_{1,1} & x_{1,2} \\%[0.5em]
 x_{2,1} & x_{2,2} \\%[0.5em]
 x_{3,1} & x_{3,2} \\%[0.5em]
-\end{bmatrix}
-\end{displaymath}
+\end{bmatrix} &
+\end{flalign}
 
-\begin{displaymath}
-\matr{Y} =
+\begin{flalign}
+\matr{Y} &=
 \begin{bmatrix}
 y_{1,1} & y_{1,2} \\%[0.5em]
 y_{2,1} & y_{2,2} \\%[0.5em]
 y_{3,1} & y_{3,2} \\%[0.5em]
-\end{bmatrix}
-\end{displaymath}
+\end{bmatrix} &
+\end{flalign}
 
-Given $\matr{Z} = \matr{X} + \matr{Y}$, Z is a $3 \times 2$ matrix which can be expressed as:
+\noindent Given $\matr{Z} = \matr{X} + \matr{Y}$, Z is a $3 \times 2$ matrix which can be expressed as:
 
-\begin{align}
+\begin{flalign}
 \matr{Z} &= \begin{bmatrix}
 z_{1,1} & z_{1,2}\\[0.5em]
 z_{2,1} & z_{2,2}\\[0.5em]
 z_{3,1} & z_{3,2}\\[0.5em]
 \end{bmatrix}
+&
 \\
 &=
 \begin{bmatrix}
@@ -858,34 +944,35 @@ x_{1,1} + y_{1,1} & x_{1,2} + y_{1,2} \\[0.5em]
 x_{2,1} + y_{2,1} & x_{2,2} + y_{2,2} \\[0.5em]
 x_{3,1} + y_{3,1} & x_{3,2} + y_{3,2} \\[0.5em]
 \end{bmatrix}
-\end{align}
+\end{flalign}
 
 \subsection{Backward Pass}
 We have $\frac{\partial L}{\partial \matr{Z}}$ of shape $3 \times 2$.
 
-\begin{displaymath}
-\frac{\partial L}{\partial \matr{Z}} =
+\begin{flalign}
+\frac{\partial L}{\partial \matr{Z}} &=
 \begin{bmatrix}
 \frac{\partial L}{\partial z_{1,1}} & \frac{\partial L}{\partial z_{1,2}} \\[0.5em]
 \frac{\partial L}{\partial z_{2,1}} & \frac{\partial L}{\partial z_{2,2}} \\[0.5em]
 \frac{\partial L}{\partial z_{3,1}} & \frac{\partial L}{\partial z_{3,2}} \\[0.5em]
 \end{bmatrix}
-\end{displaymath}
+& \eqncomment{$\frac{\partial L}{\partial \matr{Z}}$ is the same shape as $\matr{Z}$ as $L$ is a scalar}
+\end{flalign}
 
-We now need to compute $\frac{\partial L}{\partial \matr{X}}$ and $\frac{\partial L}{\partial \matr{Y}}$. Using chain rule, we get:
+\noindent We now need to compute $\frac{\partial L}{\partial \matr{X}}$ and $\frac{\partial L}{\partial \matr{Y}}$. Using chain rule, we get:
 
-\begin{equation} \label{dX_matrix_addition}
-\frac{\partial L}{\partial \matr{X}} = \frac{\partial \matr{Z}}{\partial \matr{X}}\frac{\partial L}{\partial \matr{Z}}
-\end{equation}
+\begin{flalign} \label{dX_matrix_addition}
+\frac{\partial L}{\partial \matr{X}} &= \frac{\partial \matr{Z}}{\partial \matr{X}}\frac{\partial L}{\partial \matr{Z}} &
+\end{flalign}
 
-\begin{equation} \label{dY_matrix_addition}
-\frac{\partial L}{\partial \matr{Y}} = \frac{\partial \matr{Z}}{\partial \matr{Y}}\frac{\partial L}{\partial \matr{Z}}
-\end{equation}
+\begin{flalign} \label{dY_matrix_addition}
+\frac{\partial L}{\partial \matr{Y}} &= \frac{\partial \matr{Z}}{\partial \matr{Y}}\frac{\partial L}{\partial \matr{Z}} &
+\end{flalign}
 
 \subsubsection{Computing $\frac{\partial L}{\partial \matr{X}}$}
 To compute $\frac{\partial L}{\partial \matr{X}}$, we need to compute $\frac{\partial \matr{Z}}{\partial \matr{X}}$. To make it easy for us to think about and capture the Jacobian in a two dimensional matrix (as opposed to a tensor), we will reshape matrices $\matr{X}$, $\matr{Y}$ and $\matr{Z}$ as column vectors, and compute Jacobians on them. Once we have computed the column vector corresponding to $\frac{\partial L}{\partial \matr{X}}$, we will reshape it back to a matrix with the same shape as $\matr{X}$.
 
-\begin{align}
+\begin{flalign}
 \frac{\partial \matr{Z}}{\partial \matr{X}} &=
 \begin{bmatrix}
 \frac{\partial z_{1,1}}{\partial x_{1,1}} & \frac{\partial z_{1,2}}{\partial x_{1,1}} & \frac{\partial z_{2,1}}{\partial x_{1,1}} & \frac{\partial z_{2,2}}{\partial x_{1,1}} & \frac{\partial z_{3,1}}{\partial x_{1,1}} & \frac{\partial z_{3,2}}{\partial x_{1,1}}\\[0.7em]
@@ -894,7 +981,9 @@ To compute $\frac{\partial L}{\partial \matr{X}}$, we need to compute $\frac{\pa
 \frac{\partial z_{1,1}}{\partial x_{2,2}} & \frac{\partial z_{1,2}}{\partial x_{2,2}} & \frac{\partial z_{2,1}}{\partial x_{2,2}} & \frac{\partial z_{2,2}}{\partial x_{2,2}} & \frac{\partial z_{3,1}}{\partial x_{2,2}} & \frac{\partial z_{3,2}}{\partial x_{2,2}}\\[0.7em]
 \frac{\partial z_{1,1}}{\partial x_{3,1}} & \frac{\partial z_{1,2}}{\partial x_{3,1}} & \frac{\partial z_{2,1}}{\partial x_{3,1}} & \frac{\partial z_{2,2}}{\partial x_{3,1}} & \frac{\partial z_{3,1}}{\partial x_{3,1}} & \frac{\partial z_{3,2}}{\partial x_{3,1}}\\[0.7em]
 \frac{\partial z_{1,1}}{\partial x_{3,2}} & \frac{\partial z_{1,2}}{\partial x_{3,2}} & \frac{\partial z_{2,1}}{\partial x_{3,2}} & \frac{\partial z_{2,2}}{\partial x_{3,2}} & \frac{\partial z_{3,1}}{\partial x_{3,2}} & \frac{\partial z_{3,2}}{\partial x_{3,2}}\\[0.7em]
-\end{bmatrix} \nonumber
+\end{bmatrix}
+& \longeqncomment{$\matr{X}$, $\matr{Z}$ are being treated as column vectors.}{Therefore, $\frac{\partial \matr{Z}}{\partial \matr{X}}$ is of shape $6\times6$.}
+\nonumber
 \\ \label{dZbydX_matrix_addition}
 &=
 \begin{bmatrix}
@@ -905,12 +994,12 @@ To compute $\frac{\partial L}{\partial \matr{X}}$, we need to compute $\frac{\pa
 0 & 0 & 0 & 0 & 1 & 0 \\%[0.5em]
 0 & 0 & 0 & 0 & 0 & 1 \\%[0.5em]
 \end{bmatrix}
-\end{align}
+\end{flalign}
 
-Now, $\frac{\partial L}{\partial \matr{Z}}$ expressed as a column vector will be:
+\noindent Now, $\frac{\partial L}{\partial \matr{Z}}$ expressed as a column vector will be:
 
-\begin{equation} \label{dZAsColumnVector_matrix_addition_X}
-\frac{\partial L}{\partial \matr{Z}} =
+\begin{flalign} \label{dZAsColumnVector_matrix_addition}
+\frac{\partial L}{\partial \matr{Z}} &=
 \begin{bmatrix}
 \frac{\partial L}{\partial z_{1,1}} \\[0.7em]
 \frac{\partial L}{\partial z_{1,2}} \\[0.7em]
@@ -919,12 +1008,16 @@ Now, $\frac{\partial L}{\partial \matr{Z}}$ expressed as a column vector will be
 \frac{\partial L}{\partial z_{3,1}} \\[0.7em]
 \frac{\partial L}{\partial z_{3,2}} \\[0.7em]
 \end{bmatrix}
-\end{equation}
+& \eqncomment{Reshaping $\frac{\partial L}{\partial \matr{Z}}$ from shape $3 \times 2$ to $6 \times 1$}
+\end{flalign}
 
-Plugging equations \ref{dZbydX_matrix_addition} and \ref{dZAsColumnVector_matrix_addition_X} into equation \ref{dX_matrix_addition}, we get:
+\noindent Plugging equations \ref{dZbydX_matrix_addition} and \ref{dZAsColumnVector_matrix_addition} into equation \ref{dX_matrix_addition}, we get:
 
-\begin{align}
+\begin{flalign}
 \frac{\partial L}{\partial \matr{X}} &=
+\frac{\partial \matr{Z}}{\partial \matr{X}}\frac{\partial L}{\partial \matr{Z}} &
+\nonumber \\
+&=
 \begin{bmatrix}
 1 & 0 & 0 & 0 & 0 & 0 \\%[0.5em]
 0 & 1 & 0 & 0 & 0 & 0 \\%[0.5em]
@@ -941,6 +1034,7 @@ Plugging equations \ref{dZbydX_matrix_addition} and \ref{dZAsColumnVector_matrix
 \frac{\partial L}{\partial z_{3,1}} \\[0.7em]
 \frac{\partial L}{\partial z_{3,2}} \\[0.7em]
 \end{bmatrix}
+& \eqncomment{$\matr{X}$, $\matr{Z}$ and $\frac{\partial L}{\partial \matr{Z}}$ are being treated as column vectors}
 \nonumber \\
 &=
 \begin{bmatrix}
@@ -951,12 +1045,13 @@ Plugging equations \ref{dZbydX_matrix_addition} and \ref{dZAsColumnVector_matrix
 \frac{\partial L}{\partial z_{3,1}} \\[0.7em]
 \frac{\partial L}{\partial z_{3,2}} \\[0.7em]
 \end{bmatrix} \label{dXAsColumnVector_matrix_addition}
-\end{align}
+\end{flalign}
 
-Now, reshaping column vector in equation \ref{dXAsColumnVector_matrix_addition} as a matrix of shape $\matr{X}$, we get:
+\noindent Reshaping column vector in equation \ref{dXAsColumnVector_matrix_addition} as a matrix of shape $\matr{X}$, we get:
 
-\begin{align}
+\begin{flalign}
 \frac{\partial L}{\partial \matr{X}} &=
+\underbrace{
 \begin{bmatrix}
 \frac{\partial L}{\partial z_{1,1}} &
 \frac{\partial L}{\partial z_{1,2}} \\[0.7em]
@@ -964,24 +1059,18 @@ Now, reshaping column vector in equation \ref{dXAsColumnVector_matrix_addition} 
 \frac{\partial L}{\partial z_{2,2}} \\[0.7em]
 \frac{\partial L}{\partial z_{3,1}} &
 \frac{\partial L}{\partial z_{3,2}} \\[0.7em]
-\end{bmatrix}
-\nonumber \\
-&=
-\begin{bmatrix}
-\frac{\partial L}{\partial z_{1,1}} & \frac{\partial L}{\partial z_{1,2}} \\[0.5em]
-\frac{\partial L}{\partial z_{2,1}} & \frac{\partial L}{\partial z_{2,2}} \\[0.5em]
-\frac{\partial L}{\partial z_{3,1}} & \frac{\partial L}{\partial z_{3,2}} \\[0.5em]
-\end{bmatrix}
+\end{bmatrix}}_{\frac{\partial L}{\partial \matr{Z}}}
+&
 \nonumber \\
 &=
 \frac{\partial L}{\partial \matr{Z}}
-\end{align}
+\end{flalign}
 
 \subsubsection{Computing $\frac{\partial L}{\partial \matr{Y}}$}
 To compute $\frac{\partial L}{\partial \matr{Y}}$, we need to compute $\frac{\partial \matr{Z}}{\partial \matr{Y}}$. To make it easy for us to think about and capture the Jacobian in a two dimensional matrix (as opposed to a tensor), we will reshape matrices $\matr{X}$, $\matr{Y}$ and $\matr{Z}$ as column vectors, and compute Jacobians on them. Once we have computed the column vector corresponding to $\frac{\partial L}{\partial \matr{Y}}$, we will reshape it back to a matrix with the same shape as $\matr{Y}$.
 
-\begin{align}
-\frac{\partial \matr{Z}}{\partial \matr{X}} &=
+\begin{flalign}
+\frac{\partial \matr{Z}}{\partial \matr{Y}} &=
 \begin{bmatrix}
 \frac{\partial z_{1,1}}{\partial y_{1,1}} & \frac{\partial z_{1,2}}{\partial y_{1,1}} & \frac{\partial z_{2,1}}{\partial y_{1,1}} & \frac{\partial z_{2,2}}{\partial y_{1,1}} & \frac{\partial z_{3,1}}{\partial y_{1,1}} & \frac{\partial z_{3,2}}{\partial y_{1,1}}\\[0.7em]
 \frac{\partial z_{1,1}}{\partial y_{1,2}} & \frac{\partial z_{1,2}}{\partial y_{1,2}} & \frac{\partial z_{2,1}}{\partial y_{1,2}} & \frac{\partial z_{2,2}}{\partial y_{1,2}} & \frac{\partial z_{3,1}}{\partial y_{1,2}} & \frac{\partial z_{3,2}}{\partial y_{1,2}}\\[0.7em]
@@ -989,7 +1078,9 @@ To compute $\frac{\partial L}{\partial \matr{Y}}$, we need to compute $\frac{\pa
 \frac{\partial z_{1,1}}{\partial y_{2,2}} & \frac{\partial z_{1,2}}{\partial y_{2,2}} & \frac{\partial z_{2,1}}{\partial y_{2,2}} & \frac{\partial z_{2,2}}{\partial y_{2,2}} & \frac{\partial z_{3,1}}{\partial y_{2,2}} & \frac{\partial z_{3,2}}{\partial y_{2,2}}\\[0.7em]
 \frac{\partial z_{1,1}}{\partial y_{3,1}} & \frac{\partial z_{1,2}}{\partial y_{3,1}} & \frac{\partial z_{2,1}}{\partial y_{3,1}} & \frac{\partial z_{2,2}}{\partial y_{3,1}} & \frac{\partial z_{3,1}}{\partial y_{3,1}} & \frac{\partial z_{3,2}}{\partial y_{3,1}}\\[0.7em]
 \frac{\partial z_{1,1}}{\partial y_{3,2}} & \frac{\partial z_{1,2}}{\partial y_{3,2}} & \frac{\partial z_{2,1}}{\partial y_{3,2}} & \frac{\partial z_{2,2}}{\partial y_{3,2}} & \frac{\partial z_{3,1}}{\partial y_{3,2}} & \frac{\partial z_{3,2}}{\partial y_{3,2}}\\[0.7em]
-\end{bmatrix} \nonumber
+\end{bmatrix}
+& \longeqncomment{$\matr{Y}$, $\matr{Z}$ are being treated as column vectors.}{Therefore, $\frac{\partial \matr{Z}}{\partial \matr{Y}}$ is of shape $6\times6$.}
+\nonumber
 \\ \label{dZbydY_matrix_addition}
 &=
 \begin{bmatrix}
@@ -1000,26 +1091,12 @@ To compute $\frac{\partial L}{\partial \matr{Y}}$, we need to compute $\frac{\pa
 0 & 0 & 0 & 0 & 1 & 0 \\%[0.5em]
 0 & 0 & 0 & 0 & 0 & 1 \\%[0.5em]
 \end{bmatrix}
-\end{align}
+\end{flalign}
 
-Now, $\frac{\partial L}{\partial \matr{Z}}$ expressed as a column vector will be:
+\noindent Plugging equations \ref{dZbydY_matrix_addition} and \ref{dZAsColumnVector_matrix_addition} into equation \ref{dY_matrix_addition}, we get:
 
-\begin{equation} \label{dZAsColumnVector_matrix_addition_Y}
-\frac{\partial L}{\partial \matr{Z}} =
-\begin{bmatrix}
-\frac{\partial L}{\partial z_{1,1}} \\[0.7em]
-\frac{\partial L}{\partial z_{1,2}} \\[0.7em]
-\frac{\partial L}{\partial z_{2,1}} \\[0.7em]
-\frac{\partial L}{\partial z_{2,2}} \\[0.7em]
-\frac{\partial L}{\partial z_{3,1}} \\[0.7em]
-\frac{\partial L}{\partial z_{3,2}} \\[0.7em]
-\end{bmatrix}
-\end{equation}
-
-Plugging equations \ref{dZbydX_matrix_addition} and \ref{dZAsColumnVector_matrix_addition_Y} into equation \ref{dY_matrix_addition}, we get:
-
-\begin{align}
-\frac{\partial L}{\partial \matr{X}} &=
+\begin{flalign}
+\frac{\partial L}{\partial \matr{Y}} &=
 \begin{bmatrix}
 1 & 0 & 0 & 0 & 0 & 0 \\%[0.5em]
 0 & 1 & 0 & 0 & 0 & 0 \\%[0.5em]
@@ -1036,6 +1113,7 @@ Plugging equations \ref{dZbydX_matrix_addition} and \ref{dZAsColumnVector_matrix
 \frac{\partial L}{\partial z_{3,1}} \\[0.7em]
 \frac{\partial L}{\partial z_{3,2}} \\[0.7em]
 \end{bmatrix}
+& \eqncomment{$\matr{Y}$, $\matr{Z}$ and $\frac{\partial L}{\partial \matr{Z}}$ are being treated as column vectors}
 \nonumber \\
 &=
 \begin{bmatrix}
@@ -1046,12 +1124,13 @@ Plugging equations \ref{dZbydX_matrix_addition} and \ref{dZAsColumnVector_matrix
 \frac{\partial L}{\partial z_{3,1}} \\[0.7em]
 \frac{\partial L}{\partial z_{3,2}} \\[0.7em]
 \end{bmatrix} \label{dYAsColumnVector_matrix_addition}
-\end{align}
+\end{flalign}
 
-Now, reshaping column vector in equation \ref{dYAsColumnVector_matrix_addition} as a matrix of shape $\matr{Y}$, we get:
+\noindent Reshaping column vector in equation \ref{dYAsColumnVector_matrix_addition} as a matrix of shape $\matr{Y}$, we get:
 
-\begin{align}
+\begin{flalign}
 \frac{\partial L}{\partial \matr{Y}} &=
+\underbrace{
 \begin{bmatrix}
 \frac{\partial L}{\partial z_{1,1}} &
 \frac{\partial L}{\partial z_{1,2}} \\[0.7em]
@@ -1059,69 +1138,64 @@ Now, reshaping column vector in equation \ref{dYAsColumnVector_matrix_addition} 
 \frac{\partial L}{\partial z_{2,2}} \\[0.7em]
 \frac{\partial L}{\partial z_{3,1}} &
 \frac{\partial L}{\partial z_{3,2}} \\[0.7em]
-\end{bmatrix}
-\nonumber \\
-&=
-\begin{bmatrix}
-\frac{\partial L}{\partial z_{1,1}} & \frac{\partial L}{\partial z_{1,2}} \\[0.5em]
-\frac{\partial L}{\partial z_{2,1}} & \frac{\partial L}{\partial z_{2,2}} \\[0.5em]
-\frac{\partial L}{\partial z_{3,1}} & \frac{\partial L}{\partial z_{3,2}} \\[0.5em]
-\end{bmatrix}
+\end{bmatrix}}_{\frac{\partial L}{\partial \matr{Z}}}
+&
 \nonumber \\
 &=
 \frac{\partial L}{\partial \matr{Z}}
-\end{align}
+\end{flalign}
 
 \section{Transpose}
 \subsection{Forward Pass}
 Suppose we are given a matrix $\matr{X}$ of shape $3 \times 2$. Let $\matr{Z} = \transpose{\matr{X}}$. $\matr{Z}$ will be of shape $2 \times 3$.
 
-\begin{displaymath}
-\matr{X} =
+\begin{flalign}
+\matr{X} &=
 \begin{bmatrix}
 x_{1,1} & x_{1,2} \\%[0.5em]
 x_{2,1} & x_{2,2} \\%[0.5em]
 x_{3,1} & x_{3,2} \\%[0.5em]
-\end{bmatrix}
-\end{displaymath}
+\end{bmatrix} &
+\end{flalign}
 
-$\matr{Z}$ can be expressed as:
+\noindent $\matr{Z}$ can be expressed as:
 
-\begin{align}
+\begin{flalign}
 \matr{Z} &=
 \begin{bmatrix}
 z_{1,1} & z_{1,2} & z_{1,3}\\%[0.5em]
 z_{2,1} & z_{2,2} & z_{2,3}\\%[0.5em]
-\end{bmatrix}
+\end{bmatrix} &
 \nonumber \\
 &=
 \begin{bmatrix}
 x_{1,1} & x_{2,1} & x_{3,1} \\%[0.5em]
 x_{1,2} & x_{2,2} & x_{3,2} \\%[0.5em]
 \end{bmatrix}
-\end{align}
+\end{flalign}
 
 \subsection{Backward Pass}
 We have $\frac{\partial L}{\partial \matr{Z}}$ of shape $2 \times 3$.
 
-\begin{displaymath}
-\frac{\partial L}{\partial \matr{Z}} =
+\begin{flalign}
+\frac{\partial L}{\partial \matr{Z}} &=
 \begin{bmatrix}
 \frac{\partial L}{\partial z_{1,1}} & \frac{\partial L}{\partial z_{1,2}} & \frac{\partial L}{\partial z_{1,3}} \\[0.5em]
 \frac{\partial L}{\partial z_{2,1}} & \frac{\partial L}{\partial z_{2,2}} & \frac{\partial L}{\partial z_{2,3}} \\[0.5em]
 \end{bmatrix}
-\end{displaymath}
+& \eqncomment{$\frac{\partial L}{\partial \matr{Z}}$ is the same shape as $\matr{Z}$ as $L$ is a scalar}
+\end{flalign}
 
-We now need to compute $\frac{\partial L}{\partial \matr{X}}$. Using chain rule, we get:
+\noindent We now need to compute $\frac{\partial L}{\partial \matr{X}}$. Using chain rule, we get:
 
-\begin{equation} \label{dX_transpose}
-\frac{\partial L}{\partial \matr{X}} = \frac{\partial \matr{Z}}{\partial \matr{X}}\frac{\partial L}{\partial \matr{Z}}
-\end{equation}
+\begin{flalign} \label{dX_transpose}
+\frac{\partial L}{\partial \matr{X}} &= \frac{\partial \matr{Z}}{\partial \matr{X}}\frac{\partial L}{\partial \matr{Z}} &
+\end{flalign}
 
 \subsubsection{Computing $\frac{\partial L}{\partial \matr{X}}$}
 To compute $\frac{\partial L}{\partial \matr{X}}$, we need to compute $\frac{\partial \matr{Z}}{\partial \matr{X}}$. To make it easy for us to think about and capture the Jacobian in a two dimensional matrix (as opposed to a tensor), we will reshape matrices $\matr{X}$ and $\matr{Z}$ as column vectors, and compute Jacobians on them. Once we have computed the column vector corresponding to $\frac{\partial L}{\partial \matr{X}}$, we will reshape it back to a matrix with the same shape as $\matr{X}$.
 
-\begin{align}
+\begin{flalign}
 \frac{\partial \matr{Z}}{\partial \matr{X}} &=
 \begin{bmatrix}
 \frac{\partial z_{1,1}}{\partial x_{1,1}} & \frac{\partial z_{1,2}}{\partial x_{1,1}} & \frac{\partial z_{1,3}}{\partial x_{1,1}} & \frac{\partial z_{2,1}}{\partial x_{1,1}} & \frac{\partial z_{2,2}}{\partial x_{1,1}} & \frac{\partial z_{3,3}}{\partial x_{1,1}}\\[0.7em]
@@ -1130,7 +1204,9 @@ To compute $\frac{\partial L}{\partial \matr{X}}$, we need to compute $\frac{\pa
 \frac{\partial z_{1,1}}{\partial x_{2,2}} & \frac{\partial z_{1,2}}{\partial x_{2,2}} & \frac{\partial z_{1,3}}{\partial x_{2,2}} & \frac{\partial z_{2,1}}{\partial x_{2,2}} & \frac{\partial z_{2,2}}{\partial x_{2,2}} & \frac{\partial z_{3,3}}{\partial x_{2,2}}\\[0.7em]
 \frac{\partial z_{1,1}}{\partial x_{3,1}} & \frac{\partial z_{1,2}}{\partial x_{3,1}} & \frac{\partial z_{1,3}}{\partial x_{3,1}} & \frac{\partial z_{2,1}}{\partial x_{3,1}} & \frac{\partial z_{2,2}}{\partial x_{3,1}} & \frac{\partial z_{3,3}}{\partial x_{3,1}}\\[0.7em]
 \frac{\partial z_{1,1}}{\partial x_{3,2}} & \frac{\partial z_{1,2}}{\partial x_{3,2}} & \frac{\partial z_{1,3}}{\partial x_{3,2}} & \frac{\partial z_{2,1}}{\partial x_{3,2}} & \frac{\partial z_{2,2}}{\partial x_{3,2}} & \frac{\partial z_{3,3}}{\partial x_{3,2}}\\[0.7em]
-\end{bmatrix} \nonumber
+\end{bmatrix}
+& \longeqncomment{$\matr{X}$, $\matr{Z}$ are being treated as column vectors.}{Therefore, $\frac{\partial \matr{Z}}{\partial \matr{X}}$ is of shape $6\times6$.}
+\nonumber
 \\ \label{dZbydX_transpose}
 &=
 \begin{bmatrix}
@@ -1141,12 +1217,12 @@ To compute $\frac{\partial L}{\partial \matr{X}}$, we need to compute $\frac{\pa
 0 & 0 & 1 & 0 & 0 & 0 \\%[0.5em]
 0 & 0 & 0 & 0 & 0 & 1 \\%[0.5em]
 \end{bmatrix}
-\end{align}
+\end{flalign}
 
-Now, $\frac{\partial L}{\partial \matr{Z}}$ expressed as a column vector will be:
+\noindent Now, $\frac{\partial L}{\partial \matr{Z}}$ expressed as a column vector will be:
 
-\begin{equation} \label{dZAsColumnVector_transpose}
-\frac{\partial L}{\partial \matr{Z}} =
+\begin{flalign} \label{dZAsColumnVector_transpose}
+\frac{\partial L}{\partial \matr{Z}} &=
 \begin{bmatrix}
 \frac{\partial L}{\partial z_{1,1}} \\[0.7em]
 \frac{\partial L}{\partial z_{1,2}} \\[0.7em]
@@ -1155,13 +1231,16 @@ Now, $\frac{\partial L}{\partial \matr{Z}}$ expressed as a column vector will be
 \frac{\partial L}{\partial z_{2,2}} \\[0.7em]
 \frac{\partial L}{\partial z_{2,3}} \\[0.7em]
 \end{bmatrix}
-\end{equation}
+& \eqncomment{Reshaping $\frac{\partial L}{\partial \matr{Z}}$ from shape $2 \times 3$ to $6 \times 1$}
+\end{flalign}
 
+\noindent Plugging equations \ref{dZbydX_transpose} and \ref{dZAsColumnVector_transpose} into equation \ref{dX_transpose}, we get:
 
-Plugging equations \ref{dZbydX_transpose} and \ref{dZAsColumnVector_transpose} into equation \ref{dX_transpose}, we get:
-
-\begin{align}
+\begin{flalign}
 \frac{\partial L}{\partial \matr{X}} &=
+\frac{\partial \matr{Z}}{\partial \matr{X}}\frac{\partial L}{\partial \matr{Z}} &
+\nonumber \\
+&=
 \begin{bmatrix}
 1 & 0 & 0 & 0 & 0 & 0 \\%[0.5em]
 0 & 0 & 0 & 1 & 0 & 0 \\%[0.5em]
@@ -1178,6 +1257,7 @@ Plugging equations \ref{dZbydX_transpose} and \ref{dZAsColumnVector_transpose} i
 \frac{\partial L}{\partial z_{2,2}} \\[0.7em]
 \frac{\partial L}{\partial z_{2,3}} \\[0.7em]
 \end{bmatrix}
+& \eqncomment{$\matr{X}$, $\matr{Z}$ and $\frac{\partial L}{\partial \matr{Z}}$ are being treated as column vectors}
 \nonumber \\
 &=
 \begin{bmatrix}
@@ -1188,11 +1268,11 @@ Plugging equations \ref{dZbydX_transpose} and \ref{dZAsColumnVector_transpose} i
 \frac{\partial L}{\partial z_{1,3}} \\[0.7em]
 \frac{\partial L}{\partial z_{2,3}} \\[0.7em]
 \end{bmatrix} \label{dXAsColumnVector_transpose}
-\end{align}
+\end{flalign}
 
-Now, reshaping column vector in equation \ref{dXAsColumnVector_transpose} as a matrix of shape $\matr{X}$, we get:
+\noindent Reshaping column vector in equation \ref{dXAsColumnVector_transpose} as a matrix of shape $\matr{X}$, we get:
 
-\begin{align}
+\begin{flalign}
 \frac{\partial L}{\partial \matr{X}} &=
 \begin{bmatrix}
 \frac{\partial L}{\partial z_{1,1}} &
@@ -1202,17 +1282,19 @@ Now, reshaping column vector in equation \ref{dXAsColumnVector_transpose} as a m
 \frac{\partial L}{\partial z_{1,3}} &
 \frac{\partial L}{\partial z_{2,3}} \\[0.7em]
 \end{bmatrix}
+&
 \nonumber \\
 &=
+\underbrace{
 \transpose{
 \begin{bmatrix}
 \frac{\partial L}{\partial z_{1,1}} & \frac{\partial L}{\partial z_{1,2}} & \frac{\partial L}{\partial z_{1,3}} \\[0.5em]
 \frac{\partial L}{\partial z_{2,1}} & \frac{\partial L}{\partial z_{2,2}} & \frac{\partial L}{\partial z_{2,3}} \\[0.5em]
-\end{bmatrix}}
+\end{bmatrix}}}_{\transpose{\frac{\partial L}{\partial \matr{Z}}}}
 \nonumber \\
 &=
 \transpose{\frac{\partial L}{\partial \matr{Z}}}
-\end{align}
+\end{flalign}
 
 \section{Sum along axis=0}
 \subsection{Forward Pass}

--- a/student-contributions/BackPropagationBasicMatrixOperations.tex
+++ b/student-contributions/BackPropagationBasicMatrixOperations.tex
@@ -59,7 +59,7 @@
 \author{
   Ashish Jain \\
   Stanford University \\
-  \texttt{ashishj@stanford.edu}
+  \texttt{ashishj@stanford.edu/cs231n@ashishjain.io}
  }
 \date{\today}
 
@@ -1300,51 +1300,53 @@ To compute $\frac{\partial L}{\partial \matr{X}}$, we need to compute $\frac{\pa
 \subsection{Forward Pass}
 Suppose we are given a matrix $\matr{X}$ of shape $3 \times 2$. Let $\vecr{z}$ = \verb|np.sum(|${\matr{X}}$\verb|, axis=0)|. $\vecr{z}$ will be of shape $1 \times 2$.
 
-\begin{displaymath}
-\matr{X} =
+\begin{flalign}
+\matr{X} &=
 \begin{bmatrix}
 x_{1,1} & x_{1,2} \\%[0.5em]
 x_{2,1} & x_{2,2} \\%[0.5em]
 x_{3,1} & x_{3,2} \\%[0.5em]
-\end{bmatrix}
-\end{displaymath}
+\end{bmatrix} &
+\end{flalign}
 
-$\vecr{z}$ can be expressed as:
+\noindent $\vecr{z}$ can be expressed as:
 
-\begin{align}
+\begin{flalign}
 \vecr{z} &=
 \begin{bmatrix}
 z_{1,1} & z_{1,2} \\%[0.5em]
 \end{bmatrix}
+&
 \nonumber \\
 &=
 \begin{bmatrix}
 x_{1,1} + x_{2,1} + x_{3,1} &
 x_{1,2} + x_{2,2} + x_{3,2} \\%[0.5em]
 \end{bmatrix}
-\end{align}
+\end{flalign}
 
 \subsection{Backward Pass}
 We have $\frac{\partial L}{\partial \vecr{z}}$ of shape $1 \times 2$.
 
-\begin{displaymath}
-\frac{\partial L}{\partial \matr{Z}} =
+\begin{flalign}
+\frac{\partial L}{\partial \vecr{z}} &=
 \begin{bmatrix}
 \frac{\partial L}{\partial z_{1,1}} & \frac{\partial L}{\partial z_{1,2}} \\[0.3em]
 \end{bmatrix}
-\end{displaymath}
+& \eqncomment{$\frac{\partial L}{\partial \vecr{z}}$ is the same shape as $\vecr{z}$ as $L$ is a scalar}
+\end{flalign}
 
-We now need to compute $\frac{\partial L}{\partial \matr{X}}$. Using chain rule, we get:
+\noindent We now need to compute $\frac{\partial L}{\partial \matr{X}}$. Using chain rule, we get:
 
-\begin{equation} \label{dX_sum_along_axis_0}
-\frac{\partial L}{\partial \matr{X}} = \frac{\partial \vecr{z}}{\partial \matr{X}}\frac{\partial L}{\partial \vecr{z}}
-\end{equation}
+\begin{flalign} \label{dX_sum_along_axis_0}
+\frac{\partial L}{\partial \matr{X}} &= \frac{\partial \vecr{z}}{\partial \matr{X}}\frac{\partial L}{\partial \vecr{z}} &
+\end{flalign}
 
 \subsubsection{Computing $\frac{\partial L}{\partial \matr{X}}$}
 To compute $\frac{\partial L}{\partial \matr{X}}$, we need to compute $\frac{\partial \vecr{z}}{\partial \matr{X}}$. To make it easy for us to think about and capture the Jacobian in a two dimensional matrix (as opposed to a tensor), we will reshape matrix $\matr{X}$ as well as vector $\vecr{z}$ as column vectors, and compute Jacobians on them. Once we have computed the column vector corresponding to $\frac{\partial L}{\partial \matr{X}}$, we will reshape it back to a matrix with the same shape as $\matr{X}$.
 
-\begin{align}
-\frac{\partial \matr{Z}}{\partial \matr{X}} &=
+\begin{flalign}
+\frac{\partial \vecr{z}}{\partial \matr{X}} &=
 \begin{bmatrix}
 \frac{\partial z_{1,1}}{\partial x_{1,1}} & \frac{\partial z_{1,2}}{\partial x_{1,1}} \\[0.7em]
 \frac{\partial z_{1,1}}{\partial x_{1,2}} & \frac{\partial z_{1,2}}{\partial x_{1,2}} \\[0.7em]
@@ -1352,7 +1354,9 @@ To compute $\frac{\partial L}{\partial \matr{X}}$, we need to compute $\frac{\pa
 \frac{\partial z_{1,1}}{\partial x_{2,2}} & \frac{\partial z_{1,2}}{\partial x_{2,2}} \\[0.7em]
 \frac{\partial z_{1,1}}{\partial x_{3,1}} & \frac{\partial z_{1,2}}{\partial x_{3,1}} \\[0.7em]
 \frac{\partial z_{1,1}}{\partial x_{3,2}} & \frac{\partial z_{1,2}}{\partial x_{3,2}} \\[0.7em]
-\end{bmatrix} \nonumber
+\end{bmatrix}
+& \longeqncomment{$\matr{X}$, $\vecr{z}$ are being treated as column vectors.}{Therefore, $\frac{\partial \vecr{z}}{\partial \matr{X}}$ is of shape $6\times2$.}
+\nonumber
 \\ \label{dZbydX_sum_along_axis_0}
 &=
 \begin{bmatrix}
@@ -1363,22 +1367,26 @@ To compute $\frac{\partial L}{\partial \matr{X}}$, we need to compute $\frac{\pa
 1 & 0 \\%[0.5em]
 0 & 1 \\%[0.5em]
 \end{bmatrix}
-\end{align}
+\end{flalign}
 
-Now, $\frac{\partial L}{\partial \vecr{z}}$ expressed as a column vector will be:
+\noindent Now, $\frac{\partial L}{\partial \vecr{z}}$ expressed as a column vector will be:
 
-\begin{equation} \label{dZAsColumnVector_sum_along_axis_0}
-\frac{\partial L}{\partial \vecr{z}} =
+\begin{flalign} \label{dZAsColumnVector_sum_along_axis_0}
+\frac{\partial L}{\partial \vecr{z}} &=
 \begin{bmatrix}
 \frac{\partial L}{\partial z_{1,1}} \\[0.7em]
 \frac{\partial L}{\partial z_{1,2}} \\[0.7em]
-\end{bmatrix}
-\end{equation}
+\end{bmatrix} &
+& \eqncomment{Reshaping $\frac{\partial L}{\partial \vecr{z}}$ from shape $1 \times 2$ to $2 \times 1$}
+\end{flalign}
 
-Plugging equations \ref{dZbydX_sum_along_axis_0} and \ref{dZAsColumnVector_sum_along_axis_0} into equation \ref{dX_sum_along_axis_0}, we get:
+\noindent Plugging equations \ref{dZbydX_sum_along_axis_0} and \ref{dZAsColumnVector_sum_along_axis_0} into equation \ref{dX_sum_along_axis_0}, we get:
 
-\begin{align}
+\begin{flalign}
 \frac{\partial L}{\partial \matr{X}} &=
+\frac{\partial \vecr{z}}{\partial \matr{X}}\frac{\partial L}{\partial \vecr{z}} &
+\nonumber \\
+&=
 \begin{bmatrix}
 1 & 0 \\%[0.5em]
 0 & 1 \\%[0.5em]
@@ -1391,6 +1399,7 @@ Plugging equations \ref{dZbydX_sum_along_axis_0} and \ref{dZAsColumnVector_sum_a
 \frac{\partial L}{\partial z_{1,1}} \\[0.7em]
 \frac{\partial L}{\partial z_{1,2}} \\[0.7em]
 \end{bmatrix}
+& \eqncomment{$\matr{X}$, $\vecr{z}$ and $\frac{\partial L}{\partial \vecr{z}}$ are being treated as column vectors}
 \nonumber \\
 &=
 \begin{bmatrix}
@@ -1401,11 +1410,11 @@ Plugging equations \ref{dZbydX_sum_along_axis_0} and \ref{dZAsColumnVector_sum_a
 \frac{\partial L}{\partial z_{1,1}} \\[0.7em]
 \frac{\partial L}{\partial z_{1,2}} \\[0.7em]
 \end{bmatrix} \label{dXAsColumnVector_sum_along_axis_0}
-\end{align}
+\end{flalign}
 
-Now, reshaping column vector in equation \ref{dXAsColumnVector_sum_along_axis_0} as a matrix of shape $\matr{X}$, we get:
+\noindent Reshaping column vector in equation \ref{dXAsColumnVector_sum_along_axis_0} as a matrix of shape $\matr{X}$, we get:
 
-\begin{align}
+\begin{flalign}
 \frac{\partial L}{\partial \matr{X}} &=
 \begin{bmatrix}
 \frac{\partial L}{\partial z_{1,1}} &
@@ -1422,39 +1431,45 @@ Now, reshaping column vector in equation \ref{dXAsColumnVector_sum_along_axis_0}
 1 \\
 1 \\
 \end{bmatrix}
+\underbrace{
 \begin{bmatrix}
 \frac{\partial L}{\partial z_{1,1}} & \frac{\partial L}{\partial z_{1,2}} \\[0.3em]
-\end{bmatrix} \nonumber
+\end{bmatrix}}_{\frac{\partial L}{\partial \vecr{z}}}
+& \eqncomment{Decomposing into a matmul operation}
+\nonumber
 \\
 &=
 \mathbf{1}_{3,1} \frac{\partial L}{\partial \vecr{z}} \nonumber
+& \eqncomment{We are using a bold 1 namely $\mathbf{1}$ to denote matrix of ones}
 \\
 &=
 \mathbf{1}_{\text{rows}(\matr{X}),1} \frac{\partial L}{\partial \vecr{z}}
-\end{align}
+& \eqncomment{Generalizing beyond our considered example}
+\end{flalign}
 
 \section{Sum along axis=1}
 \subsection{Forward Pass}
 Suppose we are given a matrix $\matr{X}$ of shape $3 \times 2$. Let $\vecr{z}$ = \verb|np.sum(|${\matr{X}}$\verb|, axis=1)|. $\vecr{z}$ will be of shape $3 \times 1$.
 
-\begin{displaymath}
-\matr{X} =
+\begin{flalign}
+\matr{X} &=
 \begin{bmatrix}
 x_{1,1} & x_{1,2} \\%[0.5em]
 x_{2,1} & x_{2,2} \\%[0.5em]
 x_{3,1} & x_{3,2} \\%[0.5em]
-\end{bmatrix}
-\end{displaymath}
+\end{bmatrix} &
+\end{flalign}
 
-$\vecr{z}$ can be expressed as:
+\noindent $\vecr{z}$ can be expressed as:
 
-\begin{align}
+\begin{flalign}
 \vecr{z} &=
 \begin{bmatrix}
 z_{1,1} \\
 z_{2,1} \\
 z_{3,1} \\
 \end{bmatrix}
+&
 \nonumber \\
 &=
 \begin{bmatrix}
@@ -1462,31 +1477,32 @@ x_{1,1} + x_{1,2} \\
 x_{2,1} + x_{2,2} \\
 x_{3,1} + x_{3,2} \\
 \end{bmatrix}
-\end{align}
+\end{flalign}
 
 \subsection{Backward Pass}
 We have $\frac{\partial L}{\partial \vecr{z}}$ of shape $3 \times 1$.
 
-\begin{align}
-\frac{\partial L}{\partial \matr{Z}} =
+\begin{flalign}
+\frac{\partial L}{\partial \vecr{z}} &=
 \begin{bmatrix}
 \frac{\partial L}{\partial z_{1,1}} \\[0.7em]
 \frac{\partial L}{\partial z_{2,1}} \\[0.7em]
 \frac{\partial L}{\partial z_{3,1}} \\[0.7em]
 \end{bmatrix} \label{dZAsColumnVector_sum_along_axis_1}
-\end{align}
+& \eqncomment{$\frac{\partial L}{\partial \vecr{z}}$ is the same shape as $\vecr{z}$ as $L$ is a scalar}
+\end{flalign}
 
-We now need to compute $\frac{\partial L}{\partial \matr{X}}$. Using chain rule, we get:
+\noindent We now need to compute $\frac{\partial L}{\partial \matr{X}}$. Using chain rule, we get:
 
-\begin{equation} \label{dX_sum_along_axis_1}
-\frac{\partial L}{\partial \matr{X}} = \frac{\partial \vecr{z}}{\partial \matr{X}}\frac{\partial L}{\partial \vecr{z}}
-\end{equation}
+\begin{flalign} \label{dX_sum_along_axis_1}
+\frac{\partial L}{\partial \matr{X}} &= \frac{\partial \vecr{z}}{\partial \matr{X}}\frac{\partial L}{\partial \vecr{z}} &
+\end{flalign}
 
 \subsubsection{Computing $\frac{\partial L}{\partial \matr{X}}$}
 To compute $\frac{\partial L}{\partial \matr{X}}$, we need to compute $\frac{\partial \vecr{z}}{\partial \matr{X}}$. To make it easy for us to think about and capture the Jacobian in a two dimensional matrix (as opposed to a tensor), we will reshape matrix $\matr{X}$ as a column vector, and compute Jacobians on the column vectors instead. Once we have computed the column vector corresponding to $\frac{\partial L}{\partial \matr{X}}$, we will reshape it back to a matrix with the same shape as $\matr{X}$.
 
-\begin{align}
-\frac{\partial \matr{Z}}{\partial \matr{X}} &=
+\begin{flalign}
+\frac{\partial \vecr{z}}{\partial \matr{X}} &=
 \begin{bmatrix}
 \frac{\partial z_{1,1}}{\partial x_{1,1}} & \frac{\partial z_{2,1}}{\partial x_{1,1}} & \frac{\partial z_{3,1}}{\partial x_{1,1}}\\[0.7em]
 \frac{\partial z_{1,1}}{\partial x_{1,2}} & \frac{\partial z_{2,1}}{\partial x_{1,2}} & \frac{\partial z_{3,1}}{\partial x_{1,2}} \\[0.7em]
@@ -1494,7 +1510,9 @@ To compute $\frac{\partial L}{\partial \matr{X}}$, we need to compute $\frac{\pa
 \frac{\partial z_{1,1}}{\partial x_{2,2}} & \frac{\partial z_{2,1}}{\partial x_{2,2}} & \frac{\partial z_{3,1}}{\partial x_{2,2}} \\[0.7em]
 \frac{\partial z_{1,1}}{\partial x_{3,1}} & \frac{\partial z_{2,1}}{\partial x_{3,1}} & \frac{\partial z_{3,1}}{\partial x_{3,1}} \\[0.7em]
 \frac{\partial z_{1,1}}{\partial x_{3,2}} & \frac{\partial z_{2,1}}{\partial x_{3,2}} & \frac{\partial z_{3,1}}{\partial x_{3,2}} \\[0.7em]
-\end{bmatrix} \nonumber
+\end{bmatrix}
+& \longeqncomment{$\matr{X}$ is being treated as a column vector.}{Therefore, $\frac{\partial \vecr{z}}{\partial \matr{X}}$ is of shape $6\times3$.}
+\nonumber
 \\ \label{dZbydX_sum_along_axis_1}
 &=
 \begin{bmatrix}
@@ -1505,12 +1523,15 @@ To compute $\frac{\partial L}{\partial \matr{X}}$, we need to compute $\frac{\pa
 0 & 0 & 1 \\%[0.5em]
 0 & 0 & 1 \\%[0.5em]
 \end{bmatrix}
-\end{align}
+\end{flalign}
 
-Plugging equations \ref{dZbydX_sum_along_axis_1} and \ref{dZAsColumnVector_sum_along_axis_1} into equation \ref{dX_sum_along_axis_1}, we get:
+\noindent Plugging equations \ref{dZbydX_sum_along_axis_1} and \ref{dZAsColumnVector_sum_along_axis_1} into equation \ref{dX_sum_along_axis_1}, we get:
 
-\begin{align}
+\begin{flalign}
 \frac{\partial L}{\partial \matr{X}} &=
+\frac{\partial \vecr{z}}{\partial \matr{X}}\frac{\partial L}{\partial \vecr{z}} &
+\nonumber \\
+&=
 \begin{bmatrix}
 1 & 0 & 0 \\%[0.5em]
 1 & 0 & 0 \\%[0.5em]
@@ -1524,6 +1545,7 @@ Plugging equations \ref{dZbydX_sum_along_axis_1} and \ref{dZAsColumnVector_sum_a
 \frac{\partial L}{\partial z_{2,1}} \\[0.7em]
 \frac{\partial L}{\partial z_{3,1}} \\[0.7em]
 \end{bmatrix}
+& \eqncomment{$\matr{X}$ and $\frac{\partial L}{\partial \vecr{z}}$ are being treated as column vectors}
 \nonumber \\
 &=
 \begin{bmatrix}
@@ -1534,11 +1556,11 @@ Plugging equations \ref{dZbydX_sum_along_axis_1} and \ref{dZAsColumnVector_sum_a
 \frac{\partial L}{\partial z_{3,1}} \\[0.7em]
 \frac{\partial L}{\partial z_{3,1}} \\[0.7em]
 \end{bmatrix} \label{dXAsColumnVector_sum_along_axis_1}
-\end{align}
+\end{flalign}
 
-Now, reshaping column vector in equation \ref{dXAsColumnVector_sum_along_axis_1} as a matrix of shape $\matr{X}$, we get:
+\noindent Reshaping column vector in equation \ref{dXAsColumnVector_sum_along_axis_1} as a matrix of shape $\matr{X}$, we get:
 
-\begin{align}
+\begin{flalign}
 \frac{\partial L}{\partial \matr{X}} &=
 \begin{bmatrix}
 \frac{\partial L}{\partial z_{1,1}} &
@@ -1550,44 +1572,51 @@ Now, reshaping column vector in equation \ref{dXAsColumnVector_sum_along_axis_1}
 \end{bmatrix} \nonumber
 \\
 &=
+\underbrace{
 \begin{bmatrix}
 \frac{\partial L}{\partial z_{1,1}} \\[0.7em]
 \frac{\partial L}{\partial z_{2,1}} \\[0.7em]
 \frac{\partial L}{\partial z_{3,1}} \\[0.7em]
-\end{bmatrix}
+\end{bmatrix}}_{\frac{\partial L}{\partial \vecr{z}}}
 \begin{bmatrix}
 1 & 1 \\%[0.3em]
-\end{bmatrix} \nonumber
+\end{bmatrix}
+& \eqncomment{Decomposing into a matmul operation}
+\nonumber
 \\
 &=
-\frac{\partial L}{\partial \vecr{z}} \mathbf{1}_{1,2} \nonumber
+\frac{\partial L}{\partial \vecr{z}} \mathbf{1}_{1,2}
+& \eqncomment{We are using a bold 1 namely $\mathbf{1}$ to denote matrix of ones}
+\nonumber
 \\
 &=
 \frac{\partial L}{\partial \vecr{z}} \mathbf{1}_{1, \text{cols}(\matr{X})}
-\end{align}
+& \eqncomment{Generalizing beyond our considered example}
+\end{flalign}
 
 \section{Broadcasting a column vector}
 \subsection{Forward Pass}
-Suppose we are given a vector $\vecr{x}$ of shape $3 \times 1$. Let $\matr{Z} = \vecr{x} \mathbf{1}_{1,\text{C}}$. $\matr{Z}$ will be of shape $3 \times \text{C}$. Let us suppose that C = 2.
+Suppose we are given a vector $\vecr{x}$ of shape $3 \times 1$. Let $\matr{Z} = \vecr{x} \mathbf{1}_{1,\text{C}}$ where $\mathbf{1}$ denotes a matrix of ones. $\matr{Z}$ will be of shape $3 \times \text{C}$. Let us suppose that C = 2.
 
-\begin{displaymath}
-\matr{X} =
+\begin{flalign}
+\vecr{x} &=
 \begin{bmatrix}
 x_{1,1} \\%[0.5em]
 x_{2,1} \\%[0.5em]
 x_{3,1} \\%[0.5em]
-\end{bmatrix}
-\end{displaymath}
+\end{bmatrix} &
+\end{flalign}
 
-$\vecr{z}$ can be expressed as:
+\noindent $\matr{Z}$ can be expressed as:
 
-\begin{align}
-\vecr{z} &=
+\begin{flalign}
+\matr{Z} &=
 \begin{bmatrix}
 z_{1,1} & z_{1,2} \\
 z_{2,1} & z_{2,2} \\
 z_{3,1} & z_{2,3} \\
 \end{bmatrix}
+&
 \nonumber \\
 &=
 \begin{bmatrix}
@@ -1595,36 +1624,39 @@ x_{1,1} & x_{1,1} \\
 x_{2,1} & x_{2,1} \\
 x_{3,1} & x_{3,1} \\
 \end{bmatrix}
-\end{align}
+\end{flalign}
 
 \subsection{Backward Pass}
 We have $\frac{\partial L}{\partial \matr{Z}}$ of shape $3 \times 2$.
 
-\begin{align}
-\frac{\partial L}{\partial \matr{Z}} =
+\begin{flalign}
+\frac{\partial L}{\partial \matr{Z}} &=
 \begin{bmatrix}
 \frac{\partial L}{\partial z_{1,1}} & \frac{\partial L}{\partial z_{1,2}} \\[0.7em]
 \frac{\partial L}{\partial z_{2,1}} & \frac{\partial L}{\partial z_{2,2}} \\[0.7em]
 \frac{\partial L}{\partial z_{3,1}} & \frac{\partial L}{\partial z_{3,2}} \\[0.7em]
 \end{bmatrix} \label{dZAsColumnVector_column_vector}
-\end{align}
+& \eqncomment{$\frac{\partial L}{\partial \vecr{z}}$ is the same shape as $\vecr{z}$ as $L$ is a scalar}
+\end{flalign}
 
-We now need to compute $\frac{\partial L}{\partial \vecr{x}}$. Using chain rule, we get:
+\noindent We now need to compute $\frac{\partial L}{\partial \vecr{x}}$. Using chain rule, we get:
 
-\begin{equation} \label{dX_broadcast_column_vector}
-\frac{\partial L}{\partial \vecr{x}} = \frac{\partial \matr{Z}}{\partial \vecr{x}}\frac{\partial L}{\partial \matr{Z}}
-\end{equation}
+\begin{flalign} \label{dX_broadcast_column_vector}
+\frac{\partial L}{\partial \vecr{x}} &= \frac{\partial \matr{Z}}{\partial \vecr{x}}\frac{\partial L}{\partial \matr{Z}} &
+\end{flalign}
 
 \subsubsection{Computing $\frac{\partial L}{\partial \vecr{x}}$}
 To compute $\frac{\partial L}{\partial \vecr{x}}$, we need to compute $\frac{\partial \matr{Z}}{\partial \vecr{x}}$. To make it easy for us to think about and capture the Jacobian in a two dimensional matrix (as opposed to a tensor), we will reshape matrix $\matr{Z}$ as a column vector, and compute Jacobians on the column vectors instead.
 
-\begin{align}
+\begin{flalign}
 \frac{\partial \matr{Z}}{\partial \vecr{x}} &=
 \begin{bmatrix}
 \frac{\partial z_{1,1}}{\partial x_{1,1}} & \frac{\partial z_{1,2}}{\partial x_{1,1}} & \frac{\partial z_{2,1}}{\partial x_{1,1}} & \frac{\partial z_{2,2}}{\partial x_{1,1}} & \frac{\partial z_{3,1}}{\partial x_{1,1}} & \frac{\partial z_{3,2}}{\partial x_{1,1}} \\[0.7em]
 \frac{\partial z_{1,1}}{\partial x_{2,1}} & \frac{\partial z_{1,2}}{\partial x_{2,1}} & \frac{\partial z_{2,1}}{\partial x_{2,1}} & \frac{\partial z_{2,2}}{\partial x_{2,1}} & \frac{\partial z_{3,1}}{\partial x_{2,1}} & \frac{\partial z_{3,2}}{\partial x_{2,1}} \\[0.7em]
 \frac{\partial z_{1,1}}{\partial x_{3,1}} & \frac{\partial z_{1,2}}{\partial x_{3,1}} & \frac{\partial z_{2,1}}{\partial x_{3,1}} & \frac{\partial z_{2,2}}{\partial x_{3,1}} & \frac{\partial z_{3,1}}{\partial x_{3,1}} & \frac{\partial z_{3,2}}{\partial x_{3,1}} \\[0.7em]
-\end{bmatrix} \nonumber
+\end{bmatrix}
+& \longeqncomment{$\matr{Z}$ is being treated as a column vector.}{Therefore, $\frac{\partial \matr{Z}}{\partial \vecr{x}}$ is of shape $3\times6$.}
+\nonumber
 \\ \label{dZbydX_broadcast_column_vector}
 &=
 \begin{bmatrix}
@@ -1632,12 +1664,12 @@ To compute $\frac{\partial L}{\partial \vecr{x}}$, we need to compute $\frac{\pa
 0 & 0 & 1 & 1 & 0 & 0\\%[0.5em]
 0 & 0 & 0 & 0 & 1 & 1\\%[0.5em]
 \end{bmatrix}
-\end{align}
+\end{flalign}
 
-Now, $\frac{\partial L}{\partial \matr{Z}}$ expressed as a column vector will be:
+\noindent Now, $\frac{\partial L}{\partial \matr{Z}}$ expressed as a column vector will be:
 
-\begin{equation} \label{dZAsColumnVector_broadcast_column_vector}
-\frac{\partial L}{\partial \matr{Z}} =
+\begin{flalign} \label{dZAsColumnVector_broadcast_column_vector}
+\frac{\partial L}{\partial \matr{Z}} &=
 \begin{bmatrix}
 \frac{\partial L}{\partial z_{1,1}} \\[0.7em]
 \frac{\partial L}{\partial z_{1,2}} \\[0.7em]
@@ -1646,12 +1678,17 @@ Now, $\frac{\partial L}{\partial \matr{Z}}$ expressed as a column vector will be
 \frac{\partial L}{\partial z_{3,1}} \\[0.7em]
 \frac{\partial L}{\partial z_{3,2}} \\[0.7em]
 \end{bmatrix}
-\end{equation}
+& \eqncomment{Reshaping $\frac{\partial L}{\partial \matr{Z}}$ from shape $3 \times 2$ to $6 \times 1$}
+\end{flalign}
 
-Plugging equations \ref{dZbydX_broadcast_column_vector} and \ref{dZAsColumnVector_broadcast_column_vector} into equation \ref{dX_broadcast_column_vector}, we get:
+\noindent Plugging equations \ref{dZbydX_broadcast_column_vector} and \ref{dZAsColumnVector_broadcast_column_vector} into equation \ref{dX_broadcast_column_vector}, we get:
 
-\begin{align}
+\begin{flalign}
 \frac{\partial L}{\partial \vecr{x}} &=
+\frac{\partial \matr{Z}}{\partial \vecr{x}}\frac{\partial L}{\partial \matr{Z}}
+&
+\nonumber \\
+&=
 \begin{bmatrix}
 1 & 1 & 0 & 0 & 0 & 0\\%[0.5em]
 0 & 0 & 1 & 1 & 0 & 0\\%[0.5em]
@@ -1665,6 +1702,7 @@ Plugging equations \ref{dZbydX_broadcast_column_vector} and \ref{dZAsColumnVecto
 \frac{\partial L}{\partial z_{3,1}} \\[0.7em]
 \frac{\partial L}{\partial z_{3,2}} \\[0.7em]
 \end{bmatrix}
+& \eqncomment{$\matr{Z}$ and $\frac{\partial L}{\partial \matr{Z}}$ are being treated as column vectors}
 \nonumber \\
 &=
 \begin{bmatrix}
@@ -1677,86 +1715,91 @@ Plugging equations \ref{dZbydX_broadcast_column_vector} and \ref{dZAsColumnVecto
 \end{bmatrix} \nonumber
 \\
 &=
-\begin{bmatrix}
-\frac{\partial L}{\partial z_{1,1}} +
-\frac{\partial L}{\partial z_{1,2}} \\[0.7em]
-\frac{\partial L}{\partial z_{2,1}} +
-\frac{\partial L}{\partial z_{2,2}} \\[0.7em]
-\frac{\partial L}{\partial z_{3,1}} +
-\frac{\partial L}{\partial z_{3,2}} \\[0.7em]
-\end{bmatrix} \nonumber
-\\
-&=
+\underbrace{
 \begin{bmatrix}
 \frac{\partial L}{\partial z_{1,1}} & \frac{\partial L}{\partial z_{1,2}} \\[0.7em]
 \frac{\partial L}{\partial z_{2,1}} & \frac{\partial L}{\partial z_{2,2}} \\[0.7em]
 \frac{\partial L}{\partial z_{3,1}} & \frac{\partial L}{\partial z_{3,2}} \\[0.7em]
-\end{bmatrix}
+\end{bmatrix}}_{\frac{\partial L}{\partial \matr{Z}} }
 \begin{bmatrix}
 1 \\
 1 \\
-\end{bmatrix} \nonumber
+\end{bmatrix}
+& \eqncomment{Decomposing into a matmul operation}
+\nonumber
 \\
 &=
-\frac{\partial L}{\partial \matr{Z}} \mathbf{1}_{\text{C},1} \nonumber
+\frac{\partial L}{\partial \matr{Z}} \mathbf{1}_{\text{2},1}
+& \eqncomment{We are using a bold 1 namely $\mathbf{1}$ to denote matrix of ones}
+\nonumber
+\\
+&=
+\frac{\partial L}{\partial \matr{Z}} \mathbf{1}_{\text{C},1}
+& \eqncomment{Generalizing beyond our considered example}
+\nonumber
 \\
 &= \mathtt{np.sum(} \matr{Z} \mathtt{, axis=1)}
-\end{align}
+& \eqncomment{Using $\mathtt{NumPy}$ notation for brevity}
+\end{flalign}
 
 \section{Broadcasting a row vector}
 \subsection{Forward Pass}
-Suppose we are given a vector $\vecr{x}$ of shape $1 \times 3$. Let $\matr{Z} = \mathbf{1}_{\text{R},1} \vecr{x}$. $\matr{Z}$ will be of shape $\text{R} \times 3$. Let us suppose that R = 2.
+Suppose we are given a vector $\vecr{x}$ of shape $1 \times 3$. Let $\matr{Z} = \mathbf{1}_{\text{R},1} \vecr{x}$ where $\mathbf{1}$ denotes a matrix of ones. $\matr{Z}$ will be of shape $\text{R} \times 3$. Let us suppose that R = 2.
 
-\begin{displaymath}
-\matr{X} =
+\begin{flalign}
+\vecr{x} &=
 \begin{bmatrix}
 x_{1,1} & x_{1,2} & x_{1,3} \\%[0.5em]
-\end{bmatrix}
-\end{displaymath}
+\end{bmatrix} &
+\end{flalign}
 
-$\matr{Z}$ can be expressed as:
+\noindent $\matr{Z}$ can be expressed as:
 
-\begin{align}
-\vecr{z} &=
+\begin{flalign}
+\matr{Z} &=
 \begin{bmatrix}
 z_{1,1} & z_{1,2} & z_{1,3} \\
 z_{2,1} & z_{2,2} & z_{2,3} \\
 \end{bmatrix}
+&
 \nonumber \\
 &=
 \begin{bmatrix}
 x_{1,1} & x_{1,2} & x_{1,3} \\%[0.5em]
 x_{1,1} & x_{1,2} & x_{1,3} \\%[0.5em]
 \end{bmatrix}
-\end{align}
+\end{flalign}
 
 \subsection{Backward Pass}
 We have $\frac{\partial L}{\partial \matr{Z}}$ of shape $2 \times 3$.
 
-\begin{align}
-\frac{\partial L}{\partial \matr{Z}} =
+\begin{flalign}
+\frac{\partial L}{\partial \matr{Z}} &=
 \begin{bmatrix}
 \frac{\partial L}{\partial z_{1,1}} & \frac{\partial L}{\partial z_{1,2}} & \frac{\partial L}{\partial z_{1,3}}\\[0.7em]
 \frac{\partial L}{\partial z_{2,1}} & \frac{\partial L}{\partial z_{2,2}} & \frac{\partial L}{\partial z_{2,3}}\\[0.7em]
 \end{bmatrix}
-\end{align}
+& \eqncomment{$\frac{\partial L}{\partial \vecr{z}}$ is the same shape as $\vecr{z}$ as $L$ is a scalar}
+\end{flalign}
 
-We now need to compute $\frac{\partial L}{\partial \vecr{x}}$. Using chain rule, we get:
+\noindent We now need to compute $\frac{\partial L}{\partial \vecr{x}}$. Using chain rule, we get:
 
-\begin{equation} \label{dX_broadcast_row_vector}
-\frac{\partial L}{\partial \vecr{x}} = \frac{\partial \matr{Z}}{\partial \vecr{x}}\frac{\partial L}{\partial \matr{Z}}
-\end{equation}
+\begin{flalign} \label{dX_broadcast_row_vector}
+\frac{\partial L}{\partial \vecr{x}} &= \frac{\partial \matr{Z}}{\partial \vecr{x}}\frac{\partial L}{\partial \matr{Z}} &
+\end{flalign}
 
 \subsubsection{Computing $\frac{\partial L}{\partial \vecr{x}}$}
 To compute $\frac{\partial L}{\partial \vecr{x}}$, we need to compute $\frac{\partial \matr{Z}}{\partial \vecr{x}}$. To make it easy for us to think about and capture the Jacobian in a two dimensional matrix (as opposed to a tensor), we will reshape matrix $\matr{Z}$ as well as vector $\vecr{x}$ as a column vector, and compute Jacobians on the column vectors instead.
 
-\begin{align}
+\begin{flalign}
 \frac{\partial \matr{Z}}{\partial \vecr{x}} &=
 \begin{bmatrix}
 \frac{\partial z_{1,1}}{\partial x_{1,1}} & \frac{\partial z_{1,2}}{\partial x_{1,1}} & \frac{\partial z_{1,3}}{\partial x_{1,1}} & \frac{\partial z_{2,1}}{\partial x_{1,1}} & \frac{\partial z_{2,2}}{\partial x_{1,1}} & \frac{\partial z_{2,3}}{\partial x_{1,1}} \\[0.7em]
 \frac{\partial z_{1,1}}{\partial x_{1,2}} & \frac{\partial z_{1,2}}{\partial x_{1,2}} & \frac{\partial z_{1,3}}{\partial x_{1,2}} & \frac{\partial z_{2,1}}{\partial x_{1,2}} & \frac{\partial z_{2,2}}{\partial x_{1,2}} & \frac{\partial z_{2,3}}{\partial x_{1,2}} \\[0.7em]
 \frac{\partial z_{1,1}}{\partial x_{1,3}} & \frac{\partial z_{1,2}}{\partial x_{1,3}} & \frac{\partial z_{1,3}}{\partial x_{1,3}} & \frac{\partial z_{2,1}}{\partial x_{1,3}} & \frac{\partial z_{2,2}}{\partial x_{1,3}} & \frac{\partial z_{2,3}}{\partial x_{1,3}} \\[0.7em]
-\end{bmatrix} \nonumber
+\end{bmatrix}
+& \longeqncomment{$\matr{Z}$ and $\vecr{x}$ are being treated as column vectors.}{Therefore, $\frac{\partial \matr{Z}}{\partial \vecr{x}}$ is of shape $3\times6$.}
+\nonumber
 \\ \label{dZbydX_broadcast_row_vector}
 &=
 \begin{bmatrix}
@@ -1764,12 +1807,12 @@ To compute $\frac{\partial L}{\partial \vecr{x}}$, we need to compute $\frac{\pa
 0 & 1 & 0 & 0 & 1 & 0\\%[0.5em]
 0 & 0 & 1 & 0 & 0 & 1\\%[0.5em]
 \end{bmatrix}
-\end{align}
+\end{flalign}
 
-Now, $\frac{\partial L}{\partial \matr{Z}}$ expressed as a column vector will be:
+\noindent Now, $\frac{\partial L}{\partial \matr{Z}}$ expressed as a column vector will be:
 
-\begin{equation} \label{dZAsColumnVector_broadcast_row_vector}
-\frac{\partial L}{\partial \matr{Z}} =
+\begin{flalign} \label{dZAsColumnVector_broadcast_row_vector}
+\frac{\partial L}{\partial \matr{Z}} &=
 \begin{bmatrix}
 \frac{\partial L}{\partial z_{1,1}} \\[0.7em]
 \frac{\partial L}{\partial z_{1,2}} \\[0.7em]
@@ -1778,12 +1821,17 @@ Now, $\frac{\partial L}{\partial \matr{Z}}$ expressed as a column vector will be
 \frac{\partial L}{\partial z_{2,2}} \\[0.7em]
 \frac{\partial L}{\partial z_{2,3}} \\[0.7em]
 \end{bmatrix}
-\end{equation}
+& \eqncomment{Reshaping $\frac{\partial L}{\partial \matr{Z}}$ from shape $2 \times 3$ to $6 \times 1$}
+\end{flalign}
 
-Plugging equations \ref{dZbydX_broadcast_row_vector} and \ref{dZAsColumnVector_broadcast_row_vector} into equation \ref{dX_broadcast_row_vector}, we get:
+\noindent Plugging equations \ref{dZbydX_broadcast_row_vector} and \ref{dZAsColumnVector_broadcast_row_vector} into equation \ref{dX_broadcast_row_vector}, we get:
 
-\begin{align}
+\begin{flalign}
 \frac{\partial L}{\partial \vecr{x}} &=
+\frac{\partial \matr{Z}}{\partial \vecr{x}}\frac{\partial L}{\partial \matr{Z}}
+&
+\nonumber \\
+&=
 \begin{bmatrix}
 1 & 0 & 0 & 1 & 0 & 0\\%[0.5em]
 0 & 1 & 0 & 0 & 1 & 0\\%[0.5em]
@@ -1797,6 +1845,7 @@ Plugging equations \ref{dZbydX_broadcast_row_vector} and \ref{dZAsColumnVector_b
 \frac{\partial L}{\partial z_{2,2}} \\[0.7em]
 \frac{\partial L}{\partial z_{2,3}} \\[0.7em]
 \end{bmatrix}
+& \eqncomment{$\matr{Z}$, $\vecr{x}$ and $\frac{\partial L}{\partial \matr{Z}}$ are being treated as column vectors}
 \nonumber \\
 &=
 \begin{bmatrix}
@@ -1807,11 +1856,11 @@ Plugging equations \ref{dZbydX_broadcast_row_vector} and \ref{dZAsColumnVector_b
 \frac{\partial L}{\partial z_{1,3}} +
 \frac{\partial L}{\partial z_{2,3}} \\[0.7em]
 \end{bmatrix} \label{dXAsColumnVector_broadcast_row_vector}
-\end{align}
+\end{flalign}
 
-Now reshaping $\frac{\partial L}{\partial \vecr{x}}$ from column vector of shape $3 \times 1$ in equation \ref{dXAsColumnVector_broadcast_row_vector} into row vector of shape $1 \times 3$ we get:
+\noindent Now reshaping $\frac{\partial L}{\partial \vecr{x}}$ from column vector of shape $3 \times 1$ in equation \ref{dXAsColumnVector_broadcast_row_vector} into row vector of shape $1 \times 3$ we get:
 
-\begin{align}
+\begin{flalign}
 \frac{\partial L}{\partial \vecr{x}} &=
 \begin{bmatrix}
 \frac{\partial L}{\partial z_{1,1}} +
@@ -1823,17 +1872,27 @@ Now reshaping $\frac{\partial L}{\partial \vecr{x}}$ from column vector of shape
 \end{bmatrix}
 \nonumber \\
 &=
-\mathbf{1}_{1, \text{2}}
+\begin{bmatrix}
+1 & 1\\
+\end{bmatrix}
+\underbrace{
 \begin{bmatrix}
 \frac{\partial L}{\partial z_{1,1}} & \frac{\partial L}{\partial z_{1,2}} & \frac{\partial L}{\partial z_{1,3}}\\[0.7em]
 \frac{\partial L}{\partial z_{2,1}} & \frac{\partial L}{\partial z_{2,2}} & \frac{\partial L}{\partial z_{2,3}}\\[0.7em]
-\end{bmatrix}
+\end{bmatrix}}_{\frac{\partial L}{\partial \matr{Z}}}
+& \eqncomment{Decomposing into a matmul operation}
+\nonumber \\
+&=
+\mathbf{1}_{1, \text{2}} \frac{\partial L}{\partial \matr{Z}}
+& \eqncomment{We are using a bold 1 namely $\mathbf{1}$ to denote matrix of ones}
 \nonumber \\
 &=
 \mathbf{1}_{1, \text{R}} \frac{\partial L}{\partial \matr{Z}}
+& \eqncomment{Generalizing beyond our considered example}
 \nonumber \\
 &=
 \mathtt{np.sum(} \matr{Z} \mathtt{, axis=0)}
-\end{align}
+& \eqncomment{Using $\mathtt{NumPy}$ notation for brevity}
+\end{flalign}
 
 \end{document}

--- a/student-contributions/Makefile
+++ b/student-contributions/Makefile
@@ -1,0 +1,28 @@
+# You want latexmk to *always* run, because make does not have all the info.
+# Also, include non-file targets in .PHONY so they are run regardless of any
+# file of the given name existing.
+.PHONY: BackPropagationBasicMatrixOperations.pdf
+
+# The first rule in a Makefile is the one executed by default ("make"). It
+# should always be the "all" rule, so that "make" and "make all" are identical.
+all: BackPropagationBasicMatrixOperations.pdf
+
+# MAIN LATEXMK RULE
+
+CC = latexmk 
+
+# -pdf tells latexmk to generate PDF directly (instead of DVI).
+# -pdflatex="" tells latexmk to call a specific backend with specific options.
+# -use-make tells latexmk to call make for generating missing files.
+
+# -interaction=nonstopmode keeps the pdflatex backend from stopping at a
+# missing file reference and interactively asking you for an alternative.
+CFLAGS = -pdf -pdflatex="pdflatex -interaction=nonstopmode" -use-make
+
+BackPropagationBasicMatrixOperations.pdf: BackPropagationBasicMatrixOperations.tex
+	$(CC) $(CFLAGS) BackPropagationBasicMatrixOperations.tex
+
+# latexmk
+# -CA clean up (remove) all nonessential files.
+clean:
+	$(CC) -CA

--- a/student-contributions/latexmkrc
+++ b/student-contributions/latexmkrc
@@ -1,0 +1,179 @@
+# Settings
+$xdvipdfmx = "xdvipdfmx -z 6 -o %D %O %S";
+
+###############################
+# Post processing of pdf file #
+###############################
+
+# assume the jobname is 'output' for sharelatex
+my $ORIG_PDF_AGE = -M "output.pdf"; # get age of existing pdf if present
+
+END {
+    my $NEW_PDF_AGE = -M "output.pdf";
+    return if !defined($NEW_PDF_AGE); # bail out if no pdf file
+    return if defined($ORIG_PDF_AGE) && $NEW_PDF_AGE == $ORIG_PDF_AGE; # bail out if pdf was not updated
+    $qpdf //= "/usr/local/bin/qpdf";
+    $qpdf = $ENV{QPDF} if defined($ENV{QPDF}) && -x $ENV{QPDF};
+    return if ! -x $qpdf; # check that qpdf exists
+    $qpdf_opts //= "--linearize --newline-before-endstream";
+    $qpdf_opts = $ENV{QPDF_OPTS} if defined($ENV{QPDF_OPTS});
+    my $status = system($qpdf, split(' ', $qpdf_opts), "output.pdf", "output.pdf.opt");
+    my $exitcode = ($status >> 8);
+    print "qpdf exit code=$exitcode\n";
+    # qpdf returns 0 for success, 3 for warnings (output pdf still created)
+    return if !($exitcode == 0 || $exitcode == 3);
+    print "Renaming optimised file to output.pdf\n";
+    rename("output.pdf.opt", "output.pdf");
+}
+
+##############
+# Glossaries #
+##############
+add_cus_dep( 'glo', 'gls', 0, 'glo2gls' );
+add_cus_dep( 'acn', 'acr', 0, 'glo2gls');  # from Overleaf v1
+sub glo2gls {
+    system("makeglossaries $_[0]");
+}
+
+#############
+# makeindex #
+#############
+@ist = glob("*.ist");
+if (scalar(@ist) > 0) {
+    $makeindex = "makeindex -s $ist[0] %O -o %D %S";
+}
+
+################
+# nomenclature #
+################
+add_cus_dep("nlo", "nls", 0, "nlo2nls");
+sub nlo2nls {
+        system("makeindex $_[0].nlo -s nomencl.ist -o $_[0].nls -t $_[0].nlg");
+}
+
+#########
+# Knitr #
+#########
+my $root_file = $ARGV[-1];
+
+add_cus_dep( 'Rtex', 'tex', 0, 'rtex_to_tex');
+sub rtex_to_tex {
+    do_knitr("$_[0].Rtex");
+}
+
+sub do_knitr {
+    my $dirname = dirname $_[0];
+    my $basename = basename $_[0];
+    system("Rscript -e \"library('knitr'); setwd('$dirname'); knit('$basename')\"");
+}
+
+my $rtex_file = $root_file =~ s/\.tex$/.Rtex/r;
+unless (-e $root_file) {
+    if (-e $rtex_file) {
+        do_knitr($rtex_file);
+    }
+}
+
+##########
+# feynmf #
+##########
+push(@file_not_found, '^feynmf: Files .* and (.*) not found:$');
+add_cus_dep("mf", "tfm", 0, "mf_to_tfm");
+sub mf_to_tfm { system("mf '\\mode:=laserjet; input $_[0]'"); }
+
+push(@file_not_found, '^feynmf: Label file (.*) not found:$');
+add_cus_dep("mf", "t1", 0, "mf_to_label1");
+sub mf_to_label1 { system("mf '\\mode:=laserjet; input $_[0]' && touch $_[0].t1"); }
+add_cus_dep("mf", "t2", 0, "mf_to_label2");
+sub mf_to_label2 { system("mf '\\mode:=laserjet; input $_[0]' && touch $_[0].t2"); }
+add_cus_dep("mf", "t3", 0, "mf_to_label3");
+sub mf_to_label3 { system("mf '\\mode:=laserjet; input $_[0]' && touch $_[0].t3"); }
+add_cus_dep("mf", "t4", 0, "mf_to_label4");
+sub mf_to_label4 { system("mf '\\mode:=laserjet; input $_[0]' && touch $_[0].t4"); }
+add_cus_dep("mf", "t5", 0, "mf_to_label5");
+sub mf_to_label5 { system("mf '\\mode:=laserjet; input $_[0]' && touch $_[0].t5"); }
+add_cus_dep("mf", "t6", 0, "mf_to_label6");
+sub mf_to_label6 { system("mf '\\mode:=laserjet; input $_[0]' && touch $_[0].t6"); }
+add_cus_dep("mf", "t7", 0, "mf_to_label7");
+sub mf_to_label7 { system("mf '\\mode:=laserjet; input $_[0]' && touch $_[0].t7"); }
+add_cus_dep("mf", "t8", 0, "mf_to_label8");
+sub mf_to_label8 { system("mf '\\mode:=laserjet; input $_[0]' && touch $_[0].t8"); }
+add_cus_dep("mf", "t9", 0, "mf_to_label9");
+sub mf_to_label9 { system("mf '\\mode:=laserjet; input $_[0]' && touch $_[0].t9"); }
+
+##########
+# feynmp #
+##########
+push(@file_not_found, '^dvipdf: Could not find figure file (.*); continuing.$');
+add_cus_dep("mp", "1", 0, "mp_to_eps");
+sub mp_to_eps {
+    system("mpost $_[0]");
+    return 0;
+}
+
+#############
+# asymptote #
+#############
+sub asy {return system("asy --offscreen '$_[0]'");}
+add_cus_dep("asy","eps",0,"asy");
+add_cus_dep("asy","pdf",0,"asy");
+add_cus_dep("asy","tex",0,"asy");
+
+#############
+# metapost  #  # from Overleaf v1
+#############
+add_cus_dep('mp', '1', 0, 'mpost');
+sub mpost {
+    my $file = $_[0];
+    my ($name, $path) = fileparse($file);
+    pushd($path);
+    my $return = system "mpost $name";
+    popd();
+    return $return;
+}
+
+##########
+# chktex #
+##########
+unlink 'output.chktex' if -f 'output.chktex';
+if (defined $ENV{'CHKTEX_OPTIONS'}) {
+    use File::Basename;
+    use Cwd;
+
+    # identify the main file
+    my $target = $ARGV[-1];
+    my $file = basename($target);
+
+    if ($file =~ /\.tex$/) {
+        # change directory for a limited scope
+        my $orig_dir = cwd();
+        my $subdir = dirname($target);
+        chdir($subdir);
+        # run chktex on main file
+        $status = system("/usr/bin/run-chktex.sh", $orig_dir, $file);
+        # go back to original directory
+        chdir($orig_dir);
+
+        # in VALIDATE mode we always exit after running chktex
+        # otherwise we exit if EXIT_ON_ERROR is set
+
+        if ($ENV{'CHKTEX_EXIT_ON_ERROR'} || $ENV{'CHKTEX_VALIDATE'}) {
+            # chktex doesn't let us access the error info via exit status
+            # so look through the output
+            open(my $fh, "<", "output.chktex");
+            my $errors = 0;
+            {
+                local $/ = "\n";
+                while(<$fh>) {
+                    if (/^\S+:\d+:\d+: Error:/) {
+                        $errors++;
+                        print;
+                    }
+                }
+            }
+            close($fh);
+            exit(1) if $errors > 0;
+            exit(0) if $ENV{'CHKTEX_VALIDATE'};
+        }
+    }
+}


### PR DESCRIPTION
As per my conversation with Ranjay on Monday, June 7, 2021, I have added
the first draft of my agreed upon course notes. These course notes cover
backpropagation for basic matrix operations as well as limited vector
operations.

**Instructions for generating the pdf:**
I am including the `Makefile`. As long as `pdflatex` is installed on the machine (which should come with `latexmk`), you can simply navigate to the student-contributions folder where the `BackPropagationBasicMatrixOperations.tex` file and the `Makefile` live and type 'make' to generate the pdf file. `make clean` will clean the generated files.